### PR TITLE
Reduce filesystem IO from Symfony Finder

### DIFF
--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -35,10 +35,8 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forFiles()
-			->depth('> 3')
-			->path('src/Console/Commands')
 			->name('*.php')
-			->in($this->base_path);
+			->in($this->base_path.'/*/src/Console/Commands');
 	}
 	
 	public function factoryDirectoryFinder(): FinderCollection
@@ -48,10 +46,9 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forDirectories()
-			->depth('== 2')
-			->path('database/')
+			->depth(0)
 			->name('factories')
-			->in($this->base_path);
+			->in($this->base_path.'/*/database/');
 	}
 	
 	public function migrationDirectoryFinder(): FinderCollection
@@ -61,10 +58,9 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forDirectories()
-			->depth('== 2')
-			->path('database/')
+			->depth(0)
 			->name('migrations')
-			->in($this->base_path);
+			->in($this->base_path.'/*/database/');
 	}
 	
 	public function modelFileFinder(): FinderCollection
@@ -74,10 +70,8 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forFiles()
-			->depth('> 2')
-			->path('src/Models')
 			->name('*.php')
-			->in($this->base_path);
+			->in($this->base_path.'/*/src/Models');
 	}
 	
 	public function bladeComponentFileFinder() : FinderCollection
@@ -87,10 +81,8 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forFiles()
-			->depth('> 3')
-			->path('src/View/Components')
 			->name('*.php')
-			->in($this->base_path);
+			->in($this->base_path.'/*/src/View/Components');
 	}
 	
 	public function routeFileFinder(): FinderCollection
@@ -100,10 +92,9 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forFiles()
-			->depth(2)
-			->path('routes/')
+			->depth(0)
 			->name('*.php')
-			->in($this->base_path);
+			->in($this->base_path.'/*/routes');
 	}
 	
 	public function viewDirectoryFinder(): FinderCollection
@@ -113,10 +104,9 @@ class AutoDiscoveryHelper
 		}
 		
 		return FinderCollection::forDirectories()
-			->depth('== 2')
-			->path('resources/')
+			->depth(0)
 			->name('views')
-			->in($this->base_path);
+			->in($this->base_path.'/*/resources/');
 	}
 	
 	protected function basePathMissing(): bool


### PR DESCRIPTION
For legacy reasons my app runs on AWS EFS (Elastic Filesystem) which is a network attached filesystem. I am using PHP Opcache so once the source files are cached I would expect to see very little filesystem IO.

I only have 1 module but when I released to production I noticed a big increase in the amount of filesystem access. I found that the cause of the increased filesystem IO were the calls to `AutoDiscoveryHelper` which uses `Symfony\Component\Finder\Finder` to scan for files on each web request.

Example
```php
return FinderCollection::forFiles()
    ->depth('> 3')
    ->path('src/View/Components')
    ->name('*.php')
    ->in($this->base_path);
```
Due to using `->in($this->base_path)` it causes the finder to recursively scan all files below the `app-modules` directory even including things like tests which results in a lot of filesystem activity.

Example after optimizing
```php
return FinderCollection::forFiles()
    ->name('*.php')
    ->in($this->base_path.'/*/src/View/Components');
```

By making the `in()` more specific it reduces the number of files that are scanned.

All of the tests pass so as far as I know this change does not break anything.

I initially thought that the `modules:cache` command might cache the files that `AutoDiscoveryHelper` finds but it does not. I think that would be a good feature to add. I might be able to submit a PR for that if you are interested.