### PR TITLE
Caching Improvements

### DIFF
--- a/src/Console/Commands/Make/MakeModule.php
+++ b/src/Console/Commands/Make/MakeModule.php
@@ -111,7 +111,7 @@ class MakeModule extends Command
 		$this->line("Please run <kbd>composer update {$this->composer_name}</kbd>");
 		$this->newLine();
 		
-		$this->module_registry->reload();
+		$this->module_registry->clear();
 		
 		return 0;
 	}

--- a/src/Console/Commands/ModulesCache.php
+++ b/src/Console/Commands/ModulesCache.php
@@ -4,6 +4,7 @@ namespace InterNACHI\Modular\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use InterNACHI\Modular\Support\CacheHelper;
 use InterNACHI\Modular\Support\ModuleConfig;
 use InterNACHI\Modular\Support\ModuleRegistry;
 use LogicException;
@@ -15,7 +16,7 @@ class ModulesCache extends Command
 	
 	protected $description = 'Create a cache file for faster module loading';
 	
-	public function handle(ModuleRegistry $registry, Filesystem $filesystem)
+	public function handle(ModuleRegistry $registry, Filesystem $filesystem, CacheHelper $helper)
 	{
 		$this->call(ModulesClear::class);
 		
@@ -25,7 +26,7 @@ class ModulesCache extends Command
 			})
 			->toArray();
 		
-		$cache_path = $registry->getCachePath();
+		$cache_path = $helper->getFilename();
 		$cache_contents = '<?php return '.var_export($export, true).';'.PHP_EOL;
 		
 		$filesystem->put($cache_path, $cache_contents);

--- a/src/Console/Commands/ModulesClear.php
+++ b/src/Console/Commands/ModulesClear.php
@@ -4,6 +4,7 @@ namespace InterNACHI\Modular\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use InterNACHI\Modular\Support\CacheHelper;
 use InterNACHI\Modular\Support\ModuleRegistry;
 
 class ModulesClear extends Command
@@ -12,9 +13,9 @@ class ModulesClear extends Command
 	
 	protected $description = 'Remove the module cache file';
 	
-	public function handle(Filesystem $filesystem, ModuleRegistry $registry)
+	public function handle(Filesystem $filesystem, CacheHelper $helper)
 	{
-		$filesystem->delete($registry->getCachePath());
+		$filesystem->delete($helper->getFilename());
 		$this->info('Module cache cleared!');
 	}
 }

--- a/src/Console/Commands/ModulesClear.php
+++ b/src/Console/Commands/ModulesClear.php
@@ -16,6 +16,7 @@ class ModulesClear extends Command
 	public function handle(Filesystem $filesystem, CacheHelper $helper)
 	{
 		$filesystem->delete($helper->getFilename());
+		
 		$this->info('Module cache cleared!');
 	}
 }

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -120,7 +120,7 @@ class AutoDiscoveryHelper
 	
 	public function viewDirectories() : Collection
 	{
-		return $this->load('routes', function() {
+		return $this->load('view_directories', function() {
 			return $this->directoryFinder('*/resources/')
 				->depth(0)
 				->name('views')

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -95,10 +95,15 @@ class AutoDiscoveryHelper
 		});
 	}
 	
-	public function bladeComponentFileFinder() : FinderCollection
+	public function bladeComponents() : Collection
 	{
-		return $this->fileFinder('*/src/View/Components/')
-			->name('*.php');
+		return $this->load('blade_components', function() {
+			return $this->fileFinder('*/src/View/Components/')
+				->name('*.php')
+				->map(function(SplFileInfo $path) {
+					return $path->getPathname();
+				});
+		});
 	}
 	
 	public function routeFileFinder(): FinderCollection

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -118,11 +118,16 @@ class AutoDiscoveryHelper
 		});
 	}
 	
-	public function viewDirectoryFinder() : FinderCollection
+	public function viewDirectories() : Collection
 	{
-		return $this->directoryFinder('*/resources/')
-			->depth(0)
-			->name('views');
+		return $this->load('routes', function() {
+			return $this->directoryFinder('*/resources/')
+				->depth(0)
+				->name('views')
+				->map(function(SplFileInfo $path) {
+					return $path->getPathname();
+				});
+		});
 	}
 	
 	protected function load(string $name, Closure $loader) : Collection

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -84,10 +84,15 @@ class AutoDiscoveryHelper
 		});
 	}
 	
-	public function modelFileFinder(): FinderCollection
+	public function models(): Collection
 	{
-		return $this->fileFinder('*/src/Models/')
-			->name('*.php');
+		return $this->load('models', function() {
+			return $this->fileFinder('*/src/Models/')
+				->name('*.php')
+				->map(function(SplFileInfo $path) {
+					return $path->getPathname();
+				});
+		});
 	}
 	
 	public function bladeComponentFileFinder() : FinderCollection

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -72,11 +72,16 @@ class AutoDiscoveryHelper
 		});
 	}
 	
-	public function migrationDirectoryFinder() : FinderCollection
+	public function migrations() : Collection
 	{
-		return $this->directoryFinder('*/database/')
-			->depth(0)
-			->name('migrations');
+		return $this->load('migrations', function() {
+			return $this->directoryFinder('*/database/')
+				->depth(0)
+				->name('migrations')
+				->map(function(SplFileInfo $path) {
+					return $path->getPathname();
+				});
+		});
 	}
 	
 	public function modelFileFinder(): FinderCollection

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -3,11 +3,7 @@
 namespace InterNACHI\Modular\Support;
 
 use Closure;
-use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
-use ReflectionClass;
-use RuntimeException;
 use Symfony\Component\Finder\SplFileInfo;
 
 class AutoDiscoveryHelper
@@ -64,14 +60,19 @@ class AutoDiscoveryHelper
 		});
 	}
 	
-	public function factoryDirectoryFinder() : FinderCollection
+	public function legacyFactoryPaths() : Collection
 	{
-		return $this->directoryFinder('*/database/')
-			->depth(0)
-			->name('factories');
+		return $this->load('legacy_factories', function() {
+			return $this->directoryFinder('*/database')
+				->depth(0)
+				->name('factories')
+				->map(function(SplFileInfo $path) {
+					return $path->getPathname();
+				});
+		});
 	}
 	
-	public function migrationDirectoryFinder(): FinderCollection
+	public function migrationDirectoryFinder() : FinderCollection
 	{
 		return $this->directoryFinder('*/database/')
 			->depth(0)

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -106,11 +106,16 @@ class AutoDiscoveryHelper
 		});
 	}
 	
-	public function routeFileFinder(): FinderCollection
+	public function routes(): Collection
 	{
-		return $this->fileFinder('*/routes/')
-			->depth(0)
-			->name('*.php');
+		return $this->load('routes', function() {
+			return $this->fileFinder('*/routes/')
+				->depth(0)
+				->name('*.php')
+				->map(function(SplFileInfo $path) {
+					return $path->getPathname();
+				});
+		});
 	}
 	
 	public function viewDirectoryFinder() : FinderCollection

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -3,10 +3,12 @@
 namespace InterNACHI\Modular\Support;
 
 use Closure;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Collection;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\SplFileInfo;
 
-class AutoDiscoveryHelper
+class AutoDiscoveryHelper implements Arrayable
 {
 	/**
 	 * @var string
@@ -18,149 +20,190 @@ class AutoDiscoveryHelper
 	 */
 	protected $cache;
 	
+	/**
+	 * @var \Closure[] 
+	 */
+	protected $loaders;
+	
 	public function __construct(string $modules_path, CacheHelper $cache = null)
 	{
 		$this->modules_path = rtrim($modules_path, DIRECTORY_SEPARATOR);
 		$this->cache = $cache;
+		
+		$this->loaders = $this->getLoaders();
 	}
 	
-	public function modules() : Collection
+	public function toArray()
 	{
-		return $this->load('modules', function() {
-			return $this->fileFinder()
-				->depth('== 1')
-				->name('composer.json')
-				->mapWithKeys(function(SplFileInfo $composer_file) {
-					$composer_config = json_decode($composer_file->getContents(), true, 16, JSON_THROW_ON_ERROR);
-					
-					$base_path = rtrim($composer_file->getPath(), DIRECTORY_SEPARATOR);
-					
-					$name = basename($base_path);
-					
-					$namespaces = Collection::make($composer_config['autoload']['psr-4'] ?? [])
-						->mapWithKeys(function($src, $namespace) use ($base_path) {
-							$src = str_replace('/', DIRECTORY_SEPARATOR, $src);
-							$path = $base_path.DIRECTORY_SEPARATOR.$src;
-							return [$path => $namespace];
-						});
-					
-					return [$name => compact('name', 'base_path', 'namespaces')];
-				});
-		});
+		return Collection::make($this->loaders)
+			->map(function(Closure $loader) {
+				return $loader();
+			})
+			->toArray();
 	}
 	
-	public function commands() : Collection
+	public function modules() : ?Collection
 	{
-		return $this->load('commands', function() {
-			return $this->fileFinder('*/src/Console/Commands/')
-				->name('*.php')
-				->map(function(SplFileInfo $file) {
-					return $file->getPathname();
-				});
-		});
+		return $this->load('modules');
 	}
 	
-	public function legacyFactoryPaths() : Collection
+	public function commands() : ?Collection
 	{
-		return $this->load('legacy_factories', function() {
-			return $this->directoryFinder('*/database')
-				->depth(0)
-				->name('factories')
-				->map(function(SplFileInfo $path) {
-					return $path->getPathname();
-				});
-		});
+		return $this->load('commands');
 	}
 	
-	public function migrations() : Collection
+	public function legacyFactoryPaths() : ?Collection
 	{
-		return $this->load('migrations', function() {
-			return $this->directoryFinder('*/database/')
-				->depth(0)
-				->name('migrations')
-				->map(function(SplFileInfo $path) {
-					return $path->getPathname();
-				});
-		});
+		return $this->load('legacy_factories');
 	}
 	
-	public function models(): Collection
+	public function migrations() : ?Collection
 	{
-		return $this->load('models', function() {
-			return $this->fileFinder('*/src/Models/')
-				->name('*.php')
-				->map(function(SplFileInfo $path) {
-					return $path->getPathname();
-				});
-		});
+		return $this->load('migrations');
 	}
 	
-	public function bladeComponents() : Collection
+	public function models(): ?Collection
 	{
-		return $this->load('blade_components', function() {
-			return $this->fileFinder('*/src/View/Components/')
-				->name('*.php')
-				->map(function(SplFileInfo $path) {
-					return $path->getPathname();
-				});
-		});
+		return $this->load('models');
 	}
 	
-	public function routes(): Collection
+	public function bladeComponents() : ?Collection
 	{
-		return $this->load('routes', function() {
-			return $this->fileFinder('*/routes/')
-				->depth(0)
-				->name('*.php')
-				->map(function(SplFileInfo $path) {
-					return $path->getPathname();
-				});
-		});
+		return $this->load('blade_components');
 	}
 	
-	public function viewDirectories() : Collection
+	public function routes(): ?Collection
 	{
-		return $this->load('view_directories', function() {
-			return $this->directoryFinder('*/resources/')
-				->depth(0)
-				->name('views')
-				->map(function(SplFileInfo $path) {
-					return $path->getPathname();
-				});
-		});
+		return $this->load('routes');
 	}
 	
-	protected function load(string $name, Closure $loader) : Collection
+	public function viewDirectories() : ?Collection
 	{
-		$cached = $this->cache
-			? call_user_func([$this->cache, $name])
+		return $this->load('view_directories');
+	}
+	
+	protected function load(string $name) : ?Collection
+	{
+		$result = $this->cache
+			? $this->cache->get($name)
 			: null;
 		
-		return new Collection($cached ?? $loader());
+		if (!$result) {
+			$result = $this->loaders[$name]();
+		}
+		
+		if ($result instanceof EmptyFinderCollection) {
+			return null;
+		}
+		
+		return new Collection($result);
 	}
 	
 	protected function fileFinder(string $in = '') : FinderCollection
 	{
-		if ($this->modulesPathIsMissing()) {
+		try {
+			return FinderCollection::forFiles()
+				->in($this->modules_path.DIRECTORY_SEPARATOR.$in);
+		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
-		
-		return FinderCollection::forFiles()
-			->in($this->modules_path.DIRECTORY_SEPARATOR.$in);
 	}
 	
 	protected function directoryFinder(string $in = '') : FinderCollection
 	{
-		if ($this->modulesPathIsMissing()) {
+		try {
+			return FinderCollection::forDirectories()
+				->in($this->modules_path.DIRECTORY_SEPARATOR.$in);
+		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
-		
-		return FinderCollection::forDirectories()
-			->in($this->modules_path.DIRECTORY_SEPARATOR.$in);
 	}
 	
-	protected function modulesPathIsMissing() : bool
+	/**
+	 * These loaders are meant to build data that can be manipulated by
+	 * modular or cached in production. They should return a Collection
+	 * of data that contains only PHP primitive values (arrays, strings, etc).
+	 * 
+	 * @return \Closure[]
+	 */
+	protected function getLoaders(): array
 	{
-		return false === is_dir($this->modules_path);
+		return [
+			'blade_components' => function() {
+				return $this->fileFinder('*/src/View/Components/')
+					->name('*.php')
+					->map(function(SplFileInfo $path) {
+						return $path->getPathname();
+					});
+			},
+			'commands' => function() {
+				return $this->fileFinder('*/src/Console/Commands/')
+					->name('*.php')
+					->map(function(SplFileInfo $file) {
+						return $file->getPathname();
+					});
+			},
+			'legacy_factories' => function() {
+				return $this->directoryFinder('*/database')
+					->depth(0)
+					->name('factories')
+					->map(function(SplFileInfo $path) {
+						return $path->getPathname();
+					});
+			},
+			'migrations' => function() {
+				return $this->directoryFinder('*/database/')
+					->depth(0)
+					->name('migrations')
+					->map(function(SplFileInfo $path) {
+						return $path->getPathname();
+					});
+			},
+			'models' => function() {
+				return $this->fileFinder('*/src/Models/')
+					->name('*.php')
+					->map(function(SplFileInfo $path) {
+						return $path->getPathname();
+					});
+			},
+			'modules' => function() {
+				return $this->fileFinder()
+					->depth('== 1')
+					->name('composer.json')
+					->mapWithKeys(function(SplFileInfo $composer_file) {
+						$composer_config = json_decode($composer_file->getContents(), true, 16, JSON_THROW_ON_ERROR);
+						
+						$base_path = rtrim($composer_file->getPath(), DIRECTORY_SEPARATOR);
+						
+						$name = basename($base_path);
+						
+						$namespaces = Collection::make($composer_config['autoload']['psr-4'] ?? [])
+							->mapWithKeys(function($src, $namespace) use ($base_path) {
+								$src = str_replace('/', DIRECTORY_SEPARATOR, $src);
+								$path = $base_path.DIRECTORY_SEPARATOR.$src;
+								return [$path => $namespace];
+							})
+							->all();
+						
+						return [$name => compact('name', 'base_path', 'namespaces')];
+					});
+			},
+			'routes' => function() {
+				return $this->fileFinder('*/routes/')
+					->depth(0)
+					->name('*.php')
+					->map(function(SplFileInfo $path) {
+						return $path->getPathname();
+					});
+			},
+			'view_directories' => function() {
+				return $this->directoryFinder('*/resources/')
+					->depth(0)
+					->name('views')
+					->map(function(SplFileInfo $path) {
+						return $path->getPathname();
+					});
+			},
+		];
 	}
 }

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -21,6 +21,7 @@ class CacheHelper
 		'models',
 		'blade_components',
 		'routes',
+		'view_directories',
 	];
 	
 	/**

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -40,6 +40,11 @@ class CacheHelper
 		return false;
 	}
 	
+	public function getFilename(): string
+	{
+		return $this->filename;
+	}
+	
 	public function modules(array $modules = null) : ?array
 	{
 		if ($modules) {

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -19,6 +19,7 @@ class CacheHelper
 		'legacy_factories',
 		'migrations',
 		'models',
+		'blade_components',
 	];
 	
 	/**

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -16,6 +16,7 @@ class CacheHelper
 	protected static $keys = [
 		'modules',
 		'commands',
+		'legacy_factories',
 	];
 	
 	/**

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace InterNACHI\Modular\Support;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Throwable;
+
+class CacheHelper
+{
+	protected const VERSION_KEY = '__cache_version';
+	
+	protected const CACHE_VERSION = 1;
+	
+	protected const MODULES_KEY = 'modules';
+	
+	/**
+	 * @var string
+	 */
+	protected $filename;
+	
+	/**
+	 * @var array 
+	 */
+	protected $cache = [];
+	
+	public function __construct(string $filename)
+	{
+		$this->filename = $filename;
+		$this->cache[static::VERSION_KEY] = static::CACHE_VERSION;
+		
+		if (is_readable($this->filename)) {
+			$this->cache = $this->load();
+		}
+	}
+	
+	public function write(): bool
+	{
+		// FIXME
+		return false;
+	}
+	
+	public function modules(array $modules = null) : ?array
+	{
+		if ($modules) {
+			$this->cache[static::MODULES_KEY] = $modules;
+		}
+		
+		return $this->cache[static::MODULES_KEY] ?? null;
+	}
+	
+	public function commandFiles(): Collection
+	{
+		// FIXME
+	}
+	
+	public function factoryDirectories(): Collection
+	{
+		// FIXME
+	}
+	
+	public function migrationDirectories(): Collection
+	{
+		// FIXME
+	}
+	
+	public function modelFiles(): Collection
+	{
+		// FIXME
+	}
+	
+	public function bladeComponentFiles(): Collection
+	{
+		// FIXME
+	}
+	
+	public function routeFiles(): Collection
+	{
+		// FIXME
+	}
+	
+	public function viewDirectories(): Collection
+	{
+		// FIXME
+	}
+	
+	protected function load(): array
+	{
+		try {
+			$cache = include $this->filename;
+			
+			if (!is_array($cache)) {
+				return [];
+			}
+			
+			// Convert version-less cache to version "0"
+			if (!isset($cache[static::VERSION_KEY])) {
+				$cache = [
+					static::VERSION_KEY => 0,
+					static::MODULES_KEY => $cache,
+				];
+			}
+		} catch (Throwable $exception) {
+			return [];
+		}
+		
+		return $cache;
+	}
+}

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -17,6 +17,7 @@ class CacheHelper
 		'modules',
 		'commands',
 		'legacy_factories',
+		'migrations',
 	];
 	
 	/**

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -2,6 +2,7 @@
 
 namespace InterNACHI\Modular\Support;
 
+use BadMethodCallException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Throwable;
@@ -12,7 +13,10 @@ class CacheHelper
 	
 	protected const CACHE_VERSION = 1;
 	
-	protected const MODULES_KEY = 'modules';
+	protected static $keys = [
+		'modules',
+		'commands',
+	];
 	
 	/**
 	 * @var string
@@ -45,48 +49,17 @@ class CacheHelper
 		return $this->filename;
 	}
 	
-	public function modules(array $modules = null) : ?array
+	public function __call($name, $arguments)
 	{
-		if ($modules) {
-			$this->cache[static::MODULES_KEY] = $modules;
+		if (in_array($name, static::$keys, true)) {
+			if (count($arguments)) {
+				$this->cache[$name] = $arguments[0];
+			}
+			
+			return $this->cache[$name] ?? null;
 		}
 		
-		return $this->cache[static::MODULES_KEY] ?? null;
-	}
-	
-	public function commandFiles(): Collection
-	{
-		// FIXME
-	}
-	
-	public function factoryDirectories(): Collection
-	{
-		// FIXME
-	}
-	
-	public function migrationDirectories(): Collection
-	{
-		// FIXME
-	}
-	
-	public function modelFiles(): Collection
-	{
-		// FIXME
-	}
-	
-	public function bladeComponentFiles(): Collection
-	{
-		// FIXME
-	}
-	
-	public function routeFiles(): Collection
-	{
-		// FIXME
-	}
-	
-	public function viewDirectories(): Collection
-	{
-		// FIXME
+		throw new BadMethodCallException("There is no '{$name}' in the cache.");
 	}
 	
 	protected function load(): array

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -20,6 +20,7 @@ class CacheHelper
 		'migrations',
 		'models',
 		'blade_components',
+		'routes',
 	];
 	
 	/**

--- a/src/Support/CacheHelper.php
+++ b/src/Support/CacheHelper.php
@@ -18,6 +18,7 @@ class CacheHelper
 		'commands',
 		'legacy_factories',
 		'migrations',
+		'models',
 	];
 	
 	/**

--- a/src/Support/EmptyFinderCollection.php
+++ b/src/Support/EmptyFinderCollection.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace InterNACHI\Modular\Support;
+
+use BadMethodCallException;
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Traits\ForwardsCalls;
+use IteratorAggregate;
+use Symfony\Component\Finder\Finder;
+use Traversable;
+
+class EmptyFinderCollection extends FinderCollection
+{
+	public function __construct()
+	{
+		$this->finder = [];
+		$this->collection = new LazyCollection($this->finder);
+	}
+	
+	public function __call($name, $arguments)
+	{
+		if (method_exists($this->collection, $name)) {
+			$result = $this->forwardCallTo($this->collection, $name, $arguments);
+		} else {
+			$result = $this->collection;
+		}
+		
+		return $this->wrapForwardedResponse($result);
+	}
+}

--- a/src/Support/Facades/Modules.php
+++ b/src/Support/Facades/Modules.php
@@ -11,7 +11,7 @@ use InterNACHI\Modular\Support\ModuleRegistry;
  * @method static ModuleConfig|null module(string $name)
  * @method static ModuleConfig|null moduleForPath(string $path)
  * @method static Collection modules()
- * @method static Collection reload()
+ * @method static ModuleRegistry clear()
  * 
  * @see \InterNACHI\Modular\Support\ModuleRegistry
  */

--- a/src/Support/FinderCollection.php
+++ b/src/Support/FinderCollection.php
@@ -2,8 +2,8 @@
 
 namespace InterNACHI\Modular\Support;
 
-use ArrayIterator;
-use Exception;
+use BadMethodCallException;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
 use IteratorAggregate;
@@ -14,11 +14,11 @@ use Traversable;
  * @mixin \Illuminate\Support\LazyCollection
  * @mixin \Symfony\Component\Finder\Finder
  */
-class FinderCollection implements IteratorAggregate
+class FinderCollection implements IteratorAggregate, Arrayable
 {
 	use ForwardsCalls;
 	
-	protected static $prefer_collection_methods = ['filter', 'each'];
+	protected static $prefer_collection_methods = ['filter', 'each', 'getIterator', 'toArray'];
 	
 	/**
 	 * @var \Symfony\Component\Finder\Finder|Traversable
@@ -30,52 +30,67 @@ class FinderCollection implements IteratorAggregate
 	 */
 	protected $collection;
 	
-	public static function forFiles(): self
+	public static function forFiles() : self
 	{
 		return (new static())->files();
 	}
 	
-	public static function forDirectories(): self
+	public static function forDirectories() : self
 	{
 		return (new static())->directories();
 	}
 	
-	public static function empty(): self 
+	public static function empty() : EmptyFinderCollection
 	{
-		$collection = new static();
-		
-		$collection->finder = new ArrayIterator([]);
-		
-		return $collection;
+		return new EmptyFinderCollection();
 	}
 	
 	public function __construct(Finder $finder = null)
 	{
 		$this->finder = $finder ?? new Finder();
-		$this->collection = new LazyCollection();
+		$this->collection = new LazyCollection(function() {
+			foreach ($this->finder as $key => $value) {
+				yield $key => $value;
+			}
+		});
 	}
 	
 	public function getIterator()
 	{
-		return $this->collection->getIterator();
+		return $this->__call('getIterator', []);
+	}
+	
+	public function toArray()
+	{
+		return $this->__call('toArray', []);
 	}
 	
 	public function __call($name, $arguments)
 	{
-		// If we're working with an empty instance, don't do anything with calls
-		if ($this->finder instanceof ArrayIterator) {
-			return $this;
-		}
-		
 		// Forward the call either to the Finder or the LazyCollection depending
 		// on the method (always giving precedence to the Finder class unless otherwise configured)
-		if (is_callable([$this->finder, $name]) && !in_array($name, static::$prefer_collection_methods)) {
-			$result = $this->forwardCallTo($this->finder, $name, $arguments);
-		} else {
-			$this->collection->source = $this->finder;
-			$result = $this->forwardCallTo($this->collection, $name, $arguments);
+		try {
+			if (is_callable([$this->finder, $name]) && !in_array($name, static::$prefer_collection_methods)) {
+				$result = $this->forwardCallTo($this->finder, $name, $arguments);
+			} else {
+				$result = $this->forwardCallTo($this->collection, $name, $arguments);
+			}
+		} catch (BadMethodCallException $exception) {
+			// If we're chaining calls onto an intentionally empty collection, we'll just
+			// silently handle bad method calls (i.e. calls to ->in() when there's not Finder
+			// instance available). Otherwise, we'll re-throw them.
+			if (is_array($this->finder)) {
+				return $this;
+			}
+			
+			throw $exception;
 		}
 		
+		return $this->wrapForwardedResponse($result);
+	}
+	
+	protected function wrapForwardedResponse($result)
+	{
 		// If we get a Finder object back, update our internal reference and chain
 		if ($result instanceof Finder) {
 			$this->finder = $result;
@@ -85,6 +100,7 @@ class FinderCollection implements IteratorAggregate
 		// If we get a Collection object back, update our internal reference and chain
 		if ($result instanceof LazyCollection) {
 			$this->collection = $result;
+			// $this->collection->source = $this->finder;
 			return $this;
 		}
 		

--- a/src/Support/FinderCollection.php
+++ b/src/Support/FinderCollection.php
@@ -40,7 +40,7 @@ class FinderCollection
 	{
 		$collection = new static();
 		
-		$collection->finder = [];
+		$collection->finder = null;
 		
 		return $collection;
 	}
@@ -53,6 +53,11 @@ class FinderCollection
 	
 	public function __call($name, $arguments)
 	{
+		// If we're working with an empty instance, don't do anything with calls
+		if (null === $this->finder) {
+			return $this;
+		}
+		
 		// Forward the call either to the Finder or the LazyCollection depending
 		// on the method (always giving precedence to the Finder class unless otherwise configured)
 		if (is_callable([$this->finder, $name]) && !in_array($name, static::$prefer_collection_methods)) {

--- a/src/Support/FinderCollection.php
+++ b/src/Support/FinderCollection.php
@@ -2,22 +2,26 @@
 
 namespace InterNACHI\Modular\Support;
 
+use ArrayIterator;
+use Exception;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Traits\ForwardsCalls;
+use IteratorAggregate;
 use Symfony\Component\Finder\Finder;
+use Traversable;
 
 /**
  * @mixin \Illuminate\Support\LazyCollection
  * @mixin \Symfony\Component\Finder\Finder
  */
-class FinderCollection
+class FinderCollection implements IteratorAggregate
 {
 	use ForwardsCalls;
 	
 	protected static $prefer_collection_methods = ['filter', 'each'];
 	
 	/**
-	 * @var \Symfony\Component\Finder\Finder
+	 * @var \Symfony\Component\Finder\Finder|Traversable
 	 */
 	protected $finder;
 	
@@ -40,7 +44,7 @@ class FinderCollection
 	{
 		$collection = new static();
 		
-		$collection->finder = null;
+		$collection->finder = new ArrayIterator([]);
 		
 		return $collection;
 	}
@@ -51,10 +55,15 @@ class FinderCollection
 		$this->collection = new LazyCollection();
 	}
 	
+	public function getIterator()
+	{
+		return $this->collection->getIterator();
+	}
+	
 	public function __call($name, $arguments)
 	{
 		// If we're working with an empty instance, don't do anything with calls
-		if (null === $this->finder) {
+		if ($this->finder instanceof ArrayIterator) {
 			return $this;
 		}
 		

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -162,9 +162,9 @@ class ModularServiceProvider extends ServiceProvider
 		}
 		
 		$this->autoDiscoveryHelper()
-			->routeFileFinder()
-			->each(function(SplFileInfo $file) {
-				require $file->getRealPath();
+			->routes()
+			->each(function($filename) {
+				require $filename;
 			});
 	}
 	

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -172,13 +172,13 @@ class ModularServiceProvider extends ServiceProvider
 	{
 		$this->callAfterResolving('view', function(ViewFactory $view_factory) {
 			$this->autoDiscoveryHelper()
-				->viewDirectoryFinder()
-				->each(function(SplFileInfo $directory) use ($view_factory) {
-					if (!$module = $this->registry()->moduleForPath($directory->getPath())) {
-						throw new RuntimeException("Unable to determine module for '{$directory->getPath()}'");
+				->viewDirectories()
+				->each(function($directory) use ($view_factory) {
+					if (!$module = $this->registry()->moduleForPath($directory)) {
+						throw new RuntimeException("Unable to determine module for '{$directory}'");
 					}
 					
-					$view_factory->addNamespace($module->name, $directory->getRealPath());
+					$view_factory->addNamespace($module->name, $directory);
 				});
 		});
 	}

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -264,9 +264,9 @@ class ModularServiceProvider extends ServiceProvider
 	protected function registerLegacyFactories(LegacyEloquentFactory $factory) : void
 	{
 		$this->autoDiscoveryHelper()
-			->factoryDirectoryFinder()
-			->each(function(SplFileInfo $path) use ($factory) {
-				$factory->load($path->getRealPath());
+			->legacyFactoryPaths()
+			->each(function($path) use ($factory) {
+				$factory->load($path);
 			});
 	}
 	

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -225,9 +225,9 @@ class ModularServiceProvider extends ServiceProvider
 	protected function registerMigrations(Migrator $migrator) : void
 	{
 		$this->autoDiscoveryHelper()
-			->migrationDirectoryFinder()
-			->each(function(SplFileInfo $path) use ($migrator) {
-				$migrator->path($path->getRealPath());
+			->migrations()
+			->each(function($path) use ($migrator) {
+				$migrator->path($path);
 			});
 	}
 	

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -273,13 +273,13 @@ class ModularServiceProvider extends ServiceProvider
 	protected function registerPolicies(Gate $gate) : void
 	{
 		$this->autoDiscoveryHelper()
-			->modelFileFinder()
-			->each(function(SplFileInfo $file) use ($gate) {
-				if (!$module = $this->registry()->moduleForPath($file->getPath())) {
-					throw new RuntimeException("Unable to determine module for '{$file->getPath()}'");
+			->models()
+			->each(function($filename) use ($gate) {
+				if (!$module = $this->registry()->moduleForPath($filename)) {
+					throw new RuntimeException("Unable to determine module for '{$filename}'");
 				}
 				
-				$fully_qualified_model = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
+				$fully_qualified_model = $this->pathToFullyQualifiedClassName($filename, $module);
 				
 				// First, check for a policy that maps to the full namespace of the model
 				// i.e. Models/Foo/Bar -> Policies/Foo/BarPolicy

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -187,13 +187,13 @@ class ModularServiceProvider extends ServiceProvider
 	{
 		$this->callAfterResolving(BladeCompiler::class, function(BladeCompiler $blade) {
 			$this->autoDiscoveryHelper()
-				->bladeComponentFileFinder()
-				->each(function(SplFileInfo $component) use ($blade) {
-					if (!$module = $this->registry()->moduleForPath($component->getPath())) {
-						throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
+				->bladeComponents()
+				->each(function($filename) use ($blade) {
+					if (!$module = $this->registry()->moduleForPath($filename)) {
+						throw new RuntimeException("Unable to determine module for '{$filename}'");
 					}
 					
-					$fully_qualified_component = $this->pathToFullyQualifiedClassName($component->getPathname(), $module);
+					$fully_qualified_component = $this->pathToFullyQualifiedClassName($filename, $module);
 					$blade->component($fully_qualified_component, null, $module->name);
 				});
 		});

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -70,10 +70,16 @@ class ModularServiceProvider extends ServiceProvider
 			);
 		});
 		
+		$this->app->singleton(CacheHelper::class, function() {
+			return new CacheHelper(
+				$this->app->bootstrapPath('cache/modules.php')
+			);
+		});
+		
 		$this->app->singleton(AutoDiscoveryHelper::class, function($app) {
 			return new AutoDiscoveryHelper(
 				$app->make(ModuleRegistry::class),
-				$app->make(Filesystem::class)
+				$app->make(CacheHelper::class)
 			);
 		});
 		

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -305,13 +305,13 @@ class ModularServiceProvider extends ServiceProvider
 	protected function registerCommands(Artisan $artisan): void
 	{
 		$this->autoDiscoveryHelper()
-			->commandFileFinder()
-			->each(function(SplFileInfo $file) use ($artisan) {
-				if (!$module = $this->registry()->moduleForPath($file->getPath())) {
-					throw new RuntimeException("Unable to determine module for '{$file->getPath()}'");
+			->commands()
+			->each(function($filename) use ($artisan) {
+				if (!$module = $this->registry()->moduleForPath($filename)) {
+					throw new RuntimeException("Unable to determine module for '{$filename}'");
 				}
 				
-				$class_name = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
+				$class_name = $this->pathToFullyQualifiedClassName($filename, $module);
 				if ($this->isInstantiableCommand($class_name)) {
 					$artisan->resolve($class_name);
 				}

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -63,10 +63,10 @@ class ModularServiceProvider extends ServiceProvider
 	{
 		$this->mergeConfigFrom("{$this->base_dir}/config.php", 'app-modules');
 		
-		$this->app->singleton(ModuleRegistry::class, function() {
+		$this->app->singleton(ModuleRegistry::class, function($app) {
 			return new ModuleRegistry(
 				$this->getModulesBasePath(),
-				$this->app->bootstrapPath('cache/modules.php')
+				$app->make(AutoDiscoveryHelper::class)
 			);
 		});
 		
@@ -78,7 +78,7 @@ class ModularServiceProvider extends ServiceProvider
 		
 		$this->app->singleton(AutoDiscoveryHelper::class, function($app) {
 			return new AutoDiscoveryHelper(
-				$app->make(ModuleRegistry::class),
+				$this->getModulesBasePath(),
 				$app->make(CacheHelper::class)
 			);
 		});

--- a/src/Support/ModuleConfig.php
+++ b/src/Support/ModuleConfig.php
@@ -52,7 +52,7 @@ class ModuleConfig implements Arrayable
 		return [
 			'name' => $this->name,
 			'base_path' => $this->base_path,
-			'namespaces' => $this->namespaces->toArray(),
+			'namespaces' => $this->namespaces->all(),
 		];
 	}
 }

--- a/src/Support/ModuleRegistry.php
+++ b/src/Support/ModuleRegistry.php
@@ -65,7 +65,12 @@ class ModuleRegistry
 	public function modules(): Collection
 	{
 		if (null === $this->modules) {
-			$this->modules = $this->auto_discovery->modules();
+			$this->modules = $this->auto_discovery->modules()
+				->mapWithKeys(function(array $module) {
+					return [
+						$module['name'] => new ModuleConfig($module['name'], $module['base_path'], new Collection($module['namespaces']))
+					];
+				});
 		}
 		
 		return $this->modules;

--- a/src/Support/ModuleRegistry.php
+++ b/src/Support/ModuleRegistry.php
@@ -4,7 +4,6 @@ namespace InterNACHI\Modular\Support;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Symfony\Component\Finder\SplFileInfo;
 
 class ModuleRegistry
 {
@@ -64,13 +63,12 @@ class ModuleRegistry
 	
 	public function modules(): Collection
 	{
-		if (null === $this->modules) {
-			$this->modules = $this->auto_discovery->modules()
-				->mapWithKeys(function(array $module) {
-					return [
-						$module['name'] => new ModuleConfig($module['name'], $module['base_path'], new Collection($module['namespaces']))
-					];
-				});
+		if (null === $this->modules && ($modules = $this->auto_discovery->modules())) {
+			$this->modules = $modules->mapWithKeys(function(array $module) {
+				return [
+					$module['name'] => new ModuleConfig($module['name'], $module['base_path'], new Collection($module['namespaces'])),
+				];
+			});
 		}
 		
 		return $this->modules;

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -77,11 +77,7 @@ class AutoDiscoveryHelperTest extends TestCase
 			'--module' => $this->module2->name,
 		]);
 		
-		$resolved = [];
-		
-		$this->helper->modelFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
+		$resolved = $this->helper->models();
 		
 		$this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
 		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -43,11 +43,7 @@ class AutoDiscoveryHelperTest extends TestCase
 			'--module' => $this->module2->name,
 		]);
 		
-		$resolved = [];
-		
-		$this->helper->commandFileFinder()->each(function(SplFileInfo $command) use (&$resolved) {
-			$resolved[] = $command->getPathname();
-		});
+		$resolved = $this->helper->commands();
 		
 		$this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
 		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -7,6 +7,7 @@ use InterNACHI\Modular\Console\Commands\Make\MakeCommand;
 use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
 use InterNACHI\Modular\Console\Commands\Make\MakeModel;
 use InterNACHI\Modular\Support\AutoDiscoveryHelper;
+use InterNACHI\Modular\Support\CacheHelper;
 use InterNACHI\Modular\Support\ModuleRegistry;
 use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
 use Symfony\Component\Finder\SplFileInfo;
@@ -29,7 +30,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->module2 = $this->makeModule('test-module-two');
 		$this->helper = new AutoDiscoveryHelper(
 			new ModuleRegistry($this->getBasePath().'/app-modules', ''),
-			new Filesystem()
+			new CacheHelper(tempnam(sys_get_temp_dir(), 'modular-cache'))
 		);
 	}
 	

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -103,11 +103,7 @@ class AutoDiscoveryHelperTest extends TestCase
 	
 	public function test_it_finds_routes() : void
 	{
-		$resolved = [];
-		
-		$this->helper->routeFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
+		$resolved = $this->helper->routes();
 		
 		$this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
 		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -51,11 +51,7 @@ class AutoDiscoveryHelperTest extends TestCase
 	
 	public function test_it_finds_factory_directories() : void
 	{
-		$resolved = [];
-		
-		$this->helper->factoryDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
+		$resolved = $this->helper->legacyFactoryPaths();
 		
 		$this->assertContains($this->module1->path('database/factories'), $resolved);
 		$this->assertContains($this->module2->path('database/factories'), $resolved);

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -59,11 +59,7 @@ class AutoDiscoveryHelperTest extends TestCase
 	
 	public function test_it_finds_migration_directories() : void
 	{
-		$resolved = [];
-		
-		$this->helper->migrationDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
+		$resolved = $this->helper->migrations();
 		
 		$this->assertContains($this->module1->path('database/migrations'), $resolved);
 		$this->assertContains($this->module2->path('database/migrations'), $resolved);

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -28,10 +28,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		
 		$this->module1 = $this->makeModule('test-module');
 		$this->module2 = $this->makeModule('test-module-two');
-		$this->helper = new AutoDiscoveryHelper(
-			new ModuleRegistry($this->getBasePath().'/app-modules', ''),
-			new CacheHelper(tempnam(sys_get_temp_dir(), 'modular-cache'))
-		);
+		$this->helper = new AutoDiscoveryHelper($this->getBasePath().'/app-modules');
 	}
 	
 	public function test_it_finds_commands() : void

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -95,11 +95,7 @@ class AutoDiscoveryHelperTest extends TestCase
 			'--module' => $this->module2->name,
 		]);
 		
-		$resolved = [];
-		
-		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
+		$resolved = $this->helper->bladeComponents();
 		
 		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
 		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -111,11 +111,7 @@ class AutoDiscoveryHelperTest extends TestCase
 	
 	public function test_it_finds_view_directories() : void
 	{
-		$resolved = [];
-		
-		$this->helper->viewDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
+		$resolved = $this->helper->viewDirectories();
 		
 		$this->assertContains($this->module1->path('resources/views'), $resolved);
 		$this->assertContains($this->module2->path('resources/views'), $resolved);

--- a/tests/Commands/Make/MakeModuleTest.php
+++ b/tests/Commands/Make/MakeModuleTest.php
@@ -69,7 +69,7 @@ class MakeModuleTest extends TestCase
 			->expectsQuestion('Would you like to cancel and configure your module namespace first?', false)
 			->assertExitCode(0);
 		
-		Modules::reload();
+		Modules::clear();
 		
 		$this->assertTrue($fs->isDirectory($this->getBasePath().DIRECTORY_SEPARATOR.'app-modules'.DIRECTORY_SEPARATOR.'test-module'));
 		

--- a/tests/Commands/ModulesCacheTest.php
+++ b/tests/Commands/ModulesCacheTest.php
@@ -23,7 +23,11 @@ class ModulesCacheTest extends TestCase
 		
 		$cache = include $expected_path;
 		
-		$this->assertArrayHasKey('test-module', $cache);
-		$this->assertArrayHasKey('test-module-two', $cache);
+		$this->assertIsArray($cache);
+		$this->assertArrayHasKey('__cache_version', $cache);
+		$this->assertArrayHasKey('modules', $cache);
+		$this->assertIsArray($cache['modules']);
+		$this->assertArrayHasKey('test-module', $cache['modules']);
+		$this->assertArrayHasKey('test-module-two', $cache['modules']);
 	}
 }

--- a/tests/ModularServiceProviderTest.php
+++ b/tests/ModularServiceProviderTest.php
@@ -21,6 +21,10 @@ class ModularServiceProviderTest extends TestCase
 	
 	public function test_model_factory_classes_are_resolved_correctly() : void
 	{
+		if (version_compare($this->app->version(), '8.0.0', '<')) {
+			$this->markTestSkipped('Factory classes are not supported before Laravel 8.');
+		}
+		
 		$module = $this->makeModule();
 		
 		$this->assertEquals(
@@ -66,6 +70,10 @@ class ModularServiceProviderTest extends TestCase
 	
 	public function test_model_factory_classes_are_resolved_correctly_with_custom_namespace() : void
 	{
+		if (version_compare($this->app->version(), '8.0.0', '<')) {
+			$this->markTestSkipped('Factory classes are not supported before Laravel 8.');
+		}
+		
 		Factory::useNamespace('Something\\');
 		
 		$module = $this->makeModule();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,7 @@ abstract class TestCase extends Orchestra
 	{
 		parent::setUp();
 		
-		Modules::reload();
+		Modules::clear();
 		
 		$config = $this->app['config'];
 		


### PR DESCRIPTION
This is a work-in-progress branch for improvements to how modular loads and caches files. Right now, calling `php artisan modules:cache` only caches the module configurations. This adds support for caching everything that modular scans the filesystem for, improving performance (especially on slow filesystems).

The refactor isn't fully complete, but feel free to comment if you're interested.