### PR TITLE
Add sortByName to AutoDiscoveryHelper.

### DIFF
--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -7,108 +7,109 @@ use Illuminate\Filesystem\Filesystem;
 class AutoDiscoveryHelper
 {
 	/**
-	 * @var \InterNACHI\Modular\Support\ModuleRegistry 
+	 * @var \InterNACHI\Modular\Support\ModuleRegistry
 	 */
 	protected $module_registry;
-	
+
 	/**
 	 * @var \Illuminate\Filesystem\Filesystem
 	 */
 	protected $filesystem;
-	
+
 	/**
 	 * @var string
 	 */
 	protected $base_path;
-	
+
 	public function __construct(ModuleRegistry $module_registry, Filesystem $filesystem)
 	{
 		$this->module_registry = $module_registry;
 		$this->filesystem = $filesystem;
 		$this->base_path = $module_registry->getModulesPath();
 	}
-	
+
 	public function commandFileFinder(): FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forFiles()
 			->name('*.php')
 			->in($this->base_path.'/*/src/Console/Commands');
 	}
-	
+
 	public function factoryDirectoryFinder(): FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forDirectories()
 			->depth(0)
 			->name('factories')
 			->in($this->base_path.'/*/database/');
 	}
-	
+
 	public function migrationDirectoryFinder(): FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forDirectories()
 			->depth(0)
 			->name('migrations')
 			->in($this->base_path.'/*/database/');
 	}
-	
+
 	public function modelFileFinder(): FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forFiles()
 			->name('*.php')
 			->in($this->base_path.'/*/src/Models');
 	}
-	
+
 	public function bladeComponentFileFinder() : FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forFiles()
 			->name('*.php')
 			->in($this->base_path.'/*/src/View/Components');
 	}
-	
+
 	public function routeFileFinder(): FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forFiles()
 			->depth(0)
 			->name('*.php')
-			->in($this->base_path.'/*/routes');
+            ->in($this->base_path.'/*/routes')
+            ->sortByName();
 	}
-	
+
 	public function viewDirectoryFinder(): FinderCollection
 	{
 		if ($this->basePathMissing()) {
 			return FinderCollection::empty();
 		}
-		
+
 		return FinderCollection::forDirectories()
 			->depth(0)
 			->name('views')
 			->in($this->base_path.'/*/resources/');
 	}
-	
+
 	protected function basePathMissing(): bool
 	{
 		return false === $this->filesystem->isDirectory($this->base_path);

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -94,8 +94,8 @@ class AutoDiscoveryHelper
 		return FinderCollection::forFiles()
 			->depth(0)
 			->name('*.php')
-            ->in($this->base_path.'/*/routes')
-            ->sortByName();
+			->in($this->base_path.'/*/routes')
+			->sortByName();
 	}
 
 	public function viewDirectoryFinder(): FinderCollection


### PR DESCRIPTION
I want to add sortByName() to the fluent chain in InterNACHI\Modular\Support\AutoDiscoveryHelper::routeFileFinder() . This would allow us to register routes files that should be loaded before the "normal" routes files. i.e. - __online-inspector-exam-routes.php for all the route overrides that we are doing for the OIE. Keeps the main exam-routes.php from getting all cluttered with overrides