### PR TITLE
Livewire auto-discovery.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.3",
         "ext-json": "*",
-        "friendsofphp/php-cs-fixer": "^2.19"
+        "friendsofphp/php-cs-fixer": "^2.19",
+        "livewire/livewire": "^2.5"
     }
 }

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -2,34 +2,30 @@
 
 namespace InterNACHI\Modular\Console\Commands\Make;
 
-use Livewire\Commands\MakeCommand;
-use Illuminate\Support\Facades\File;
-
 use Illuminate\Support\Facades\Config;
-use Livewire\Commands\MakeLivewireCommand;
-use Livewire\Commands\FileManipulationCommand;
+use Livewire\Commands\MakeCommand;
 use Symfony\Component\Console\Input\InputOption;
 
 class MakeLivewire extends MakeCommand
 {
-    use Modularize;
+	use Modularize;
 
-    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub=default}';
+	protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub=default}';
 
-    public function __construct()
-    {
-        parent::__construct();
+	public function __construct()
+	{
+		parent::__construct();
 
-        $this->getDefinition()->addOption(
-            new InputOption(
-                '--module',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Create this resource inside an application module'
-            )
-        );
+		$this->getDefinition()->addOption(
+			new InputOption(
+				'--module',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Create this resource inside an application module'
+			)
+		);
 
-        Config::set('livewire.class_namespace', 'Modules\Blueprints');
-        Config::set('livewire.view_path', 'app-modules/blueprints/resources/livewire');
-    }
+		Config::set('livewire.class_namespace', 'Modules\Blueprints');
+		Config::set('livewire.view_path', 'app-modules/blueprints/resources/livewire');
+	}
 }

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -13,71 +13,69 @@ use Livewire\LivewireComponentsFinder;
 class MakeLivewire extends MakeCommand
 {
 	use Modularize;
-
+	
 	public function handle()
 	{
 		if ($module = $this->module()) {
 			Config::set('livewire.class_namespace', $module->qualify('Http\\Livewire'));
 			Config::set('livewire.view_path', $module->path('resources/views/livewire'));
-
+			
 			$app = $this->getLaravel();
-
+			
 			$defaultManifestPath = $app['livewire']->isRunningServerless()
 				? '/tmp/storage/bootstrap/cache/livewire-components.php'
-				: app()->bootstrapPath('cache/livewire-components.php');
-
+				: $app->bootstrapPath('cache/livewire-components.php');
+			
 			$componentsFinder = new LivewireComponentsFinder(
 				new Filesystem(),
-				config('livewire.manifest_path') ?: $defaultManifestPath,
+				Config::get('livewire.manifest_path') ?? $defaultManifestPath,
 				$module->path('src/Http/Livewire')
 			);
-
+			
 			$app->instance(LivewireComponentsFinder::class, $componentsFinder);
 		}
-
+		
 		parent::handle();
 	}
-
+	
 	protected function createClass($force = false, $inline = false)
 	{
 		if ($module = $this->module()) {
-			$directories = preg_split('/[.\/(\\\\)]+/', $this->argument('name'));
-			$directories = array_map([Str::class, 'studly'], $directories);
-
 			$name = Str::of($this->argument('name'))
 				->split('/[.\/(\\\\)]+/')
 				->map([Str::class, 'studly'])
 				->join(DIRECTORY_SEPARATOR);
-
+			
 			$classPath = $module->path('src/Http/Livewire/'.$name.'.php');
-
+			
 			if (File::exists($classPath) && !$force) {
 				$this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
 				$this->line("<fg=red;options=bold>Class already exists:</> {$this->parser->relativeClassPath()}");
-
+				
 				return false;
 			}
-
+			
 			$this->ensureDirectoryExists($classPath);
-
+			
 			File::put($classPath, $this->parser->classContents($inline));
-
+			
 			$component_name = Str::of($name)
 				->explode('/')
 				->filter()
 				->map([Str::class, 'kebab'])
 				->implode('.');
-
+			
 			$fully_qualified_component = Str::of($this->argument('name'))
 				->prepend('Http/Livewire/')
 				->split('/[.\/(\\\\)]+/')
 				->map([Str::class, 'studly'])
 				->join('\\');
-
+			
 			Livewire::component("{$module->name}::{$component_name}", $module->qualify($fully_qualified_component));
+			
 			return $classPath;
 		}
-
+		
 		return parent::createClass($force, $inline);
 	}
 }

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 class MakeLivewire extends MakeCommand
 {
-    //use Modularize;
+    use Modularize;
 
     protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub=default}';
 

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -2,21 +2,87 @@
 
 namespace InterNACHI\Modular\Console\Commands\Make;
 
-use Illuminate\Support\Facades\Config;
+use Illuminate\Filesystem\Filesystem;
+use Livewire\Livewire;
+use Illuminate\Support\Str;
 use Livewire\Commands\MakeCommand;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Config;
+use Livewire\LivewireComponentsFinder;
 use Symfony\Component\Console\Input\InputOption;
 
 class MakeLivewire extends MakeCommand
 {
-	use Modularize;
-	
-	public function handle()
-	{
-		if ($module = $this->module()) {
-			Config::set('livewire.class_namespace', $module->qualify('Http\\Livewire'));
-			Config::set('livewire.view_path', $module->path('resources/views/livewire'));
-		}
-		
-		parent::handle();
-	}
+    use Modularize;
+
+    public function handle()
+    {
+        if ($module = $this->module()) {
+            Config::set('livewire.class_namespace', $module->qualify('Http\\Livewire'));
+            Config::set('livewire.view_path', $module->path('resources/views/livewire'));
+
+            $app = $this->getLaravel();
+
+            $defaultManifestPath = $app['livewire']->isRunningServerless()
+                ? '/tmp/storage/bootstrap/cache/livewire-components.php'
+                : app()->bootstrapPath('cache/livewire-components.php');
+
+            $componentsFinder = new LivewireComponentsFinder(
+                new Filesystem,
+                config('livewire.manifest_path') ?: $defaultManifestPath,
+                $module->path('src/Http/Livewire')
+            );
+
+            $app->instance(LivewireComponentsFinder::class, $componentsFinder);
+        }
+
+        parent::handle();
+    }
+
+    protected function createClass($force = false, $inline = false)
+    {
+        if ($module = $this->module()) {
+
+            $directories = preg_split('/[.\/(\\\\)]+/', $this->argument('name'));
+            $directories = array_map([Str::class, 'studly'], $directories);
+
+
+            $name = Str::of($this->argument('name'))
+                ->split('/[.\/(\\\\)]+/')
+                ->map([Str::class, 'studly'])
+                ->join(DIRECTORY_SEPARATOR);
+
+
+            $classPath = $module->path('src/Http/Livewire/' . $name . ".php");
+
+            if (File::exists($classPath) && !$force) {
+                $this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
+                $this->line("<fg=red;options=bold>Class already exists:</> {$this->parser->relativeClassPath()}");
+
+                return false;
+            }
+
+            $this->ensureDirectoryExists($classPath);
+
+            File::put($classPath, $this->parser->classContents($inline));
+
+            $component_name = Str::of($name)
+                ->explode('/')
+                ->filter()
+                ->map([Str::class, 'kebab'])
+                ->implode('.');
+
+
+            $fully_qualified_component = Str::of($this->argument('name'))
+                ->prepend("Http/Livewire/")
+                ->split('/[.\/(\\\\)]+/')
+                ->map([Str::class, 'studly'])
+                ->join("\\");
+
+            Livewire::component("{$module->name}::{$component_name}", $module->qualify($fully_qualified_component));
+            return $classPath;
+        }
+
+        return parent::createClass($force, $inline);
+    }
 }

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -9,23 +9,14 @@ use Symfony\Component\Console\Input\InputOption;
 class MakeLivewire extends MakeCommand
 {
 	use Modularize;
-
-	protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub=default}';
-
-	public function __construct()
+	
+	public function handle()
 	{
-		parent::__construct();
-
-		$this->getDefinition()->addOption(
-			new InputOption(
-				'--module',
-				null,
-				InputOption::VALUE_REQUIRED,
-				'Create this resource inside an application module'
-			)
-		);
-
-		Config::set('livewire.class_namespace', 'Modules\Blueprints');
-		Config::set('livewire.view_path', 'app-modules/blueprints/resources/livewire');
+		if ($module = $this->module()) {
+			Config::set('livewire.class_namespace', $module->qualify('Http\\Livewire'));
+			Config::set('livewire.view_path', $module->path('resources/views/livewire'));
+		}
+		
+		parent::handle();
 	}
 }

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace InterNACHI\Modular\Console\Commands\Make;
+
+use Livewire\Commands\MakeCommand;
+use Illuminate\Support\Facades\File;
+
+use Illuminate\Support\Facades\Config;
+use Livewire\Commands\MakeLivewireCommand;
+use Livewire\Commands\FileManipulationCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class MakeLivewire extends MakeCommand
+{
+    //use Modularize;
+
+    protected $signature = 'livewire:make {name} {--force} {--inline} {--test} {--stub=default}';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->getDefinition()->addOption(
+            new InputOption(
+                '--module',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Create this resource inside an application module'
+            )
+        );
+
+        Config::set('livewire.class_namespace', 'Modules\Blueprints');
+        Config::set('livewire.view_path', 'app-modules/blueprints/resources/livewire');
+    }
+}

--- a/src/Console/Commands/Make/Modularize.php
+++ b/src/Console/Commands/Make/Modularize.php
@@ -7,94 +7,95 @@ use InterNACHI\Modular\Support\ModuleConfig;
 use InterNACHI\Modular\Support\ModuleRegistry;
 use Symfony\Component\Console\Input\InputOption;
 
+
 trait Modularize
 {
-	protected function module(): ?ModuleConfig
-	{
-		return $this->getLaravel()
-			->make(ModuleRegistry::class)
-			->module($this->option('module'));
-	}
-	
-	protected function configure()
-	{
-		parent::configure();
-		
-		$this->getDefinition()->addOption(
-			new InputOption(
-				'--module',
-				null,
-				InputOption::VALUE_REQUIRED,
-				'Create this resource inside an application module'
-			)
-		);
-	}
-	
-	protected function getDefaultNamespace($rootNamespace)
-	{
-		$namespace = parent::getDefaultNamespace($rootNamespace);
-		$module = $this->module();
-		
-		if ($module && false === strpos($rootNamespace, $module->namespaces->first())) {
-			$find = rtrim($rootNamespace, '\\');
-			$replace = rtrim($module->namespaces->first(), '\\');
-			$namespace = str_replace($find, $replace, $namespace);
-		}
-		
-		return $namespace;
-	}
-	
-	protected function qualifyClass($name)
-	{
-		$name = ltrim($name, '\\/');
-		
-		if ($module = $this->module()) {
-			if (Str::startsWith($name, $module->namespaces->first())) {
-				return $name;
-			}
-		}
-		
-		return parent::qualifyClass($name);
-	}
-	
-	protected function getPath($name)
-	{
-		if ($module = $this->module()) {
-			$name = Str::replaceFirst($module->namespaces->first(), '', $name);
-		}
-		
-		$path = parent::getPath($name);
-		
-		if ($module) {
-			// Set up our replacements as a [find -> replace] array
-			$replacements = [
-				$this->laravel->path() => $module->namespaces->keys()->first(),
-				$this->laravel->basePath('tests/Tests') => $module->path('tests'),
-				$this->laravel->databasePath() => $module->path('database'),
-			];
-			
-			// Normalize all our paths for compatibility's sake
-			$normalize = function($path) {
-				return DIRECTORY_SEPARATOR.trim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
-			};
-			
-			$find = array_map($normalize, array_keys($replacements));
-			$replace = array_map($normalize, array_values($replacements));
-			
-			// And finally apply the replacements
-			$path = str_replace($find, $replace, $path);
-		}
-		
-		return $path;
-	}
-	
-	public function call($command, array $arguments = [])
-	{
-		// Pass the --module flag on to subsequent commands
-		if ($module = $this->option('module')) {
-			$arguments['--module'] = $module;
-		}
-		
-		return $this->runCommand($command, $arguments, $this->output);
-	}
+    protected function module(): ?ModuleConfig
+    {
+        return $this->getLaravel()
+            ->make(ModuleRegistry::class)
+            ->module($this->option('module'));
+    }
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->getDefinition()->addOption(
+            new InputOption(
+                '--module',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Create this resource inside an application module'
+            )
+        );
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $namespace = parent::getDefaultNamespace($rootNamespace);
+        $module = $this->module();
+
+        if ($module && false === strpos($rootNamespace, $module->namespaces->first())) {
+            $find = rtrim($rootNamespace, '\\');
+            $replace = rtrim($module->namespaces->first(), '\\');
+            $namespace = str_replace($find, $replace, $namespace);
+        }
+
+        return $namespace;
+    }
+
+    protected function qualifyClass($name)
+    {
+        $name = ltrim($name, '\\/');
+
+        if ($module = $this->module()) {
+            if (Str::startsWith($name, $module->namespaces->first())) {
+                return $name;
+            }
+        }
+
+        return parent::qualifyClass($name);
+    }
+
+    protected function getPath($name)
+    {
+        if ($module = $this->module()) {
+            $name = Str::replaceFirst($module->namespaces->first(), '', $name);
+        }
+
+        $path = parent::getPath($name);
+
+        if ($module) {
+            // Set up our replacements as a [find -> replace] array
+            $replacements = [
+                $this->laravel->path() => $module->namespaces->keys()->first(),
+                $this->laravel->basePath('tests/Tests') => $module->path('tests'),
+                $this->laravel->databasePath() => $module->path('database'),
+            ];
+
+            // Normalize all our paths for compatibility's sake
+            $normalize = function ($path) {
+                return DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+            };
+
+            $find = array_map($normalize, array_keys($replacements));
+            $replace = array_map($normalize, array_values($replacements));
+
+            // And finally apply the replacements
+            $path = str_replace($find, $replace, $path);
+        }
+
+        return $path;
+    }
+
+    public function call($command, array $arguments = [])
+    {
+        // Pass the --module flag on to subsequent commands
+        if ($module = $this->option('module')) {
+            $arguments['--module'] = $module;
+        }
+
+        return $this->runCommand($command, $arguments, $this->output);
+    }
 }

--- a/src/Console/Commands/Make/Modularize.php
+++ b/src/Console/Commands/Make/Modularize.php
@@ -9,92 +9,92 @@ use Symfony\Component\Console\Input\InputOption;
 
 trait Modularize
 {
-    protected function module(): ?ModuleConfig
-    {
-        return $this->getLaravel()
-            ->make(ModuleRegistry::class)
-            ->module($this->option('module'));
-    }
+	protected function module(): ?ModuleConfig
+	{
+		return $this->getLaravel()
+			->make(ModuleRegistry::class)
+			->module($this->option('module'));
+	}
 
-    protected function configure()
-    {
-        parent::configure();
+	protected function configure()
+	{
+		parent::configure();
 
-        $this->getDefinition()->addOption(
-            new InputOption(
-                '--module',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Create this resource inside an application module'
-            )
-        );
-    }
+		$this->getDefinition()->addOption(
+			new InputOption(
+				'--module',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'Create this resource inside an application module'
+			)
+		);
+	}
 
-    protected function getDefaultNamespace($rootNamespace)
-    {
-        $namespace = parent::getDefaultNamespace($rootNamespace);
-        $module = $this->module();
+	protected function getDefaultNamespace($rootNamespace)
+	{
+		$namespace = parent::getDefaultNamespace($rootNamespace);
+		$module = $this->module();
 
-        if ($module && false === strpos($rootNamespace, $module->namespaces->first())) {
-            $find = rtrim($rootNamespace, '\\');
-            $replace = rtrim($module->namespaces->first(), '\\');
-            $namespace = str_replace($find, $replace, $namespace);
-        }
+		if ($module && false === strpos($rootNamespace, $module->namespaces->first())) {
+			$find = rtrim($rootNamespace, '\\');
+			$replace = rtrim($module->namespaces->first(), '\\');
+			$namespace = str_replace($find, $replace, $namespace);
+		}
 
-        return $namespace;
-    }
+		return $namespace;
+	}
 
-    protected function qualifyClass($name)
-    {
-        $name = ltrim($name, '\\/');
+	protected function qualifyClass($name)
+	{
+		$name = ltrim($name, '\\/');
 
-        if ($module = $this->module()) {
-            if (Str::startsWith($name, $module->namespaces->first())) {
-                return $name;
-            }
-        }
+		if ($module = $this->module()) {
+			if (Str::startsWith($name, $module->namespaces->first())) {
+				return $name;
+			}
+		}
 
-        return parent::qualifyClass($name);
-    }
+		return parent::qualifyClass($name);
+	}
 
-    protected function getPath($name)
-    {
-        if ($module = $this->module()) {
-            $name = Str::replaceFirst($module->namespaces->first(), '', $name);
-        }
+	protected function getPath($name)
+	{
+		if ($module = $this->module()) {
+			$name = Str::replaceFirst($module->namespaces->first(), '', $name);
+		}
 
-        $path = parent::getPath($name);
+		$path = parent::getPath($name);
 
-        if ($module) {
-            // Set up our replacements as a [find -> replace] array
-            $replacements = [
-                $this->laravel->path() => $module->namespaces->keys()->first(),
-                $this->laravel->basePath('tests/Tests') => $module->path('tests'),
-                $this->laravel->databasePath() => $module->path('database'),
-            ];
+		if ($module) {
+			// Set up our replacements as a [find -> replace] array
+			$replacements = [
+				$this->laravel->path() => $module->namespaces->keys()->first(),
+				$this->laravel->basePath('tests/Tests') => $module->path('tests'),
+				$this->laravel->databasePath() => $module->path('database'),
+			];
 
-            // Normalize all our paths for compatibility's sake
-            $normalize = function ($path) {
-                return DIRECTORY_SEPARATOR . trim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-            };
+			// Normalize all our paths for compatibility's sake
+			$normalize = function($path) {
+				return DIRECTORY_SEPARATOR.trim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+			};
 
-            $find = array_map($normalize, array_keys($replacements));
-            $replace = array_map($normalize, array_values($replacements));
+			$find = array_map($normalize, array_keys($replacements));
+			$replace = array_map($normalize, array_values($replacements));
 
-            // And finally apply the replacements
-            $path = str_replace($find, $replace, $path);
-        }
+			// And finally apply the replacements
+			$path = str_replace($find, $replace, $path);
+		}
 
-        return $path;
-    }
+		return $path;
+	}
 
-    public function call($command, array $arguments = [])
-    {
-        // Pass the --module flag on to subsequent commands
-        if ($module = $this->option('module')) {
-            $arguments['--module'] = $module;
-        }
+	public function call($command, array $arguments = [])
+	{
+		// Pass the --module flag on to subsequent commands
+		if ($module = $this->option('module')) {
+			$arguments['--module'] = $module;
+		}
 
-        return $this->runCommand($command, $arguments, $this->output);
-    }
+		return $this->runCommand($command, $arguments, $this->output);
+	}
 }

--- a/src/Console/Commands/Make/Modularize.php
+++ b/src/Console/Commands/Make/Modularize.php
@@ -15,11 +15,11 @@ trait Modularize
 			->make(ModuleRegistry::class)
 			->module($this->option('module'));
 	}
-
+	
 	protected function configure()
 	{
 		parent::configure();
-
+		
 		$this->getDefinition()->addOption(
 			new InputOption(
 				'--module',
@@ -29,42 +29,42 @@ trait Modularize
 			)
 		);
 	}
-
+	
 	protected function getDefaultNamespace($rootNamespace)
 	{
 		$namespace = parent::getDefaultNamespace($rootNamespace);
 		$module = $this->module();
-
+		
 		if ($module && false === strpos($rootNamespace, $module->namespaces->first())) {
 			$find = rtrim($rootNamespace, '\\');
 			$replace = rtrim($module->namespaces->first(), '\\');
 			$namespace = str_replace($find, $replace, $namespace);
 		}
-
+		
 		return $namespace;
 	}
-
+	
 	protected function qualifyClass($name)
 	{
 		$name = ltrim($name, '\\/');
-
+		
 		if ($module = $this->module()) {
 			if (Str::startsWith($name, $module->namespaces->first())) {
 				return $name;
 			}
 		}
-
+		
 		return parent::qualifyClass($name);
 	}
-
+	
 	protected function getPath($name)
 	{
 		if ($module = $this->module()) {
 			$name = Str::replaceFirst($module->namespaces->first(), '', $name);
 		}
-
+		
 		$path = parent::getPath($name);
-
+		
 		if ($module) {
 			// Set up our replacements as a [find -> replace] array
 			$replacements = [
@@ -72,29 +72,29 @@ trait Modularize
 				$this->laravel->basePath('tests/Tests') => $module->path('tests'),
 				$this->laravel->databasePath() => $module->path('database'),
 			];
-
+			
 			// Normalize all our paths for compatibility's sake
 			$normalize = function($path) {
 				return DIRECTORY_SEPARATOR.trim($path, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
 			};
-
+			
 			$find = array_map($normalize, array_keys($replacements));
 			$replace = array_map($normalize, array_values($replacements));
-
+			
 			// And finally apply the replacements
 			$path = str_replace($find, $replace, $path);
 		}
-
+		
 		return $path;
 	}
-
+	
 	public function call($command, array $arguments = [])
 	{
 		// Pass the --module flag on to subsequent commands
 		if ($module = $this->option('module')) {
 			$arguments['--module'] = $module;
 		}
-
+		
 		return $this->runCommand($command, $arguments, $this->output);
 	}
 }

--- a/src/Console/Commands/Make/Modularize.php
+++ b/src/Console/Commands/Make/Modularize.php
@@ -7,7 +7,6 @@ use InterNACHI\Modular\Support\ModuleConfig;
 use InterNACHI\Modular\Support\ModuleRegistry;
 use Symfony\Component\Console\Input\InputOption;
 
-
 trait Modularize
 {
     protected function module(): ?ModuleConfig

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -122,4 +122,15 @@ class AutoDiscoveryHelper
             return FinderCollection::empty();
         }
     }
+
+    public function livewireComponentFileFinder(): FinderCollection
+    {
+        try {
+            return FinderCollection::forFiles()
+                ->name('*.php')
+                ->in($this->base_path . '/*/src/Http/Livewire');
+        } catch (\Exception $e) {
+            return FinderCollection::empty();
+        }
+    }
 }

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -129,7 +129,7 @@ class AutoDiscoveryHelper
 			return FinderCollection::forFiles()
 				->name('*.php')
 				->in($this->base_path.'/*/src/Http/Livewire');
-		} catch (\Exception $e) {
+		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
 	}

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -34,7 +34,7 @@ class AutoDiscoveryHelper
 		try {
 			return FinderCollection::forFiles()
 				->name('*.php')
-				->in($this->base_path . '/*/src/Console/Commands');
+				->in($this->base_path.'/*/src/Console/Commands');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
@@ -46,7 +46,7 @@ class AutoDiscoveryHelper
 			return FinderCollection::forDirectories()
 				->depth(0)
 				->name('factories')
-				->in($this->base_path . '/*/database/');
+				->in($this->base_path.'/*/database/');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
@@ -58,7 +58,7 @@ class AutoDiscoveryHelper
 			return FinderCollection::forDirectories()
 				->depth(0)
 				->name('migrations')
-				->in($this->base_path . '/*/database/');
+				->in($this->base_path.'/*/database/');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
@@ -69,18 +69,18 @@ class AutoDiscoveryHelper
 		try {
 			return FinderCollection::forFiles()
 				->name('*.php')
-				->in($this->base_path . '/*/src/Models');
+				->in($this->base_path.'/*/src/Models');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
 	}
 
-	public function bladeComponentFileFinder(): FinderCollection
+	public function bladeComponentFileFinder() : FinderCollection
 	{
 		try {
 			return FinderCollection::forFiles()
 				->name('*.php')
-				->in($this->base_path . '/*/src/View/Components');
+				->in($this->base_path.'/*/src/View/Components');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
@@ -92,7 +92,7 @@ class AutoDiscoveryHelper
 			return FinderCollection::forFiles()
 				->depth(0)
 				->name('*.php')
-				->in($this->base_path . '/*/routes')
+				->in($this->base_path.'/*/routes')
 				->sortByName();
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
@@ -105,19 +105,19 @@ class AutoDiscoveryHelper
 			return FinderCollection::forDirectories()
 				->depth(0)
 				->name('views')
-				->in($this->base_path . '/*/resources/');
+				->in($this->base_path.'/*/resources/');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
 	}
-
-	public function langDirectoryFinder(): FinderCollection
+	
+	public function langDirectoryFinder() : FinderCollection
 	{
 		try {
 			return FinderCollection::forDirectories()
 				->depth(0)
 				->name('lang')
-				->in($this->base_path . '/*/resources/');
+				->in($this->base_path.'/*/resources/');
 		} catch (DirectoryNotFoundException $exception) {
 			return FinderCollection::empty();
 		}
@@ -128,7 +128,7 @@ class AutoDiscoveryHelper
 		try {
 			return FinderCollection::forFiles()
 				->name('*.php')
-				->in($this->base_path . '/*/src/Http/Livewire');
+				->in($this->base_path.'/*/src/Http/Livewire');
 		} catch (\Exception $e) {
 			return FinderCollection::empty();
 		}

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -7,139 +7,139 @@ use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 
 class AutoDiscoveryHelper
 {
-	/**
-	 * @var \InterNACHI\Modular\Support\ModuleRegistry
-	 */
-	protected $module_registry;
+    /**
+     * @var \InterNACHI\Modular\Support\ModuleRegistry
+     */
+    protected $module_registry;
 
-	/**
-	 * @var \Illuminate\Filesystem\Filesystem
-	 */
-	protected $filesystem;
+    /**
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $filesystem;
 
-	/**
-	 * @var string
-	 */
-	protected $base_path;
+    /**
+     * @var string
+     */
+    protected $base_path;
 
-	public function __construct(ModuleRegistry $module_registry, Filesystem $filesystem)
-	{
-		$this->module_registry = $module_registry;
-		$this->filesystem = $filesystem;
-		$this->base_path = $module_registry->getModulesPath();
-	}
+    public function __construct(ModuleRegistry $module_registry, Filesystem $filesystem)
+    {
+        $this->module_registry = $module_registry;
+        $this->filesystem = $filesystem;
+        $this->base_path = $module_registry->getModulesPath();
+    }
 
-	public function commandFileFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function commandFileFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forFiles()
-			->name('*.php')
-			->in($this->base_path.'/*/src/Console/Commands');
-	}
+        return FinderCollection::forFiles()
+            ->name('*.php')
+            ->in($this->base_path . '/*/src/Console/Commands');
+    }
 
-	public function factoryDirectoryFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function factoryDirectoryFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forDirectories()
-			->depth(0)
-			->name('factories')
-			->in($this->base_path.'/*/database/');
-	}
+        return FinderCollection::forDirectories()
+            ->depth(0)
+            ->name('factories')
+            ->in($this->base_path . '/*/database/');
+    }
 
-	public function migrationDirectoryFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function migrationDirectoryFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forDirectories()
-			->depth(0)
-			->name('migrations')
-			->in($this->base_path.'/*/database/');
-	}
+        return FinderCollection::forDirectories()
+            ->depth(0)
+            ->name('migrations')
+            ->in($this->base_path . '/*/database/');
+    }
 
-	public function modelFileFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function modelFileFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forFiles()
-			->name('*.php')
-			->in($this->base_path.'/*/src/Models');
-	}
+        return FinderCollection::forFiles()
+            ->name('*.php')
+            ->in($this->base_path . '/*/src/Models');
+    }
 
-	public function bladeComponentFileFinder() : FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function bladeComponentFileFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forFiles()
-			->name('*.php')
-			->in($this->base_path.'/*/src/View/Components');
-	}
+        return FinderCollection::forFiles()
+            ->name('*.php')
+            ->in($this->base_path . '/*/src/View/Components');
+    }
 
-	public function routeFileFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function routeFileFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forFiles()
-			->depth(0)
-			->name('*.php')
-			->in($this->base_path.'/*/routes')
-			->sortByName();
-	}
+        return FinderCollection::forFiles()
+            ->depth(0)
+            ->name('*.php')
+            ->in($this->base_path . '/*/routes')
+            ->sortByName();
+    }
 
-	public function viewDirectoryFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
+    public function viewDirectoryFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-		return FinderCollection::forDirectories()
-			->depth(0)
-			->name('views')
-			->in($this->base_path.'/*/resources/');
-	}
-	
-	public function livewireComponentFileFinder(): FinderCollection
-	{
-		if ($this->basePathMissing()) {
-		    return FinderCollection::empty();
-		}
+        return FinderCollection::forDirectories()
+            ->depth(0)
+            ->name('views')
+            ->in($this->base_path . '/*/resources/');
+    }
 
-		try {
-		    return FinderCollection::forFiles()
-			->name('*.php')
-			->in($this->base_path . '/*/src/Http/Livewire');
-		} catch (DirectoryNotFoundException $e) {
-		    return FinderCollection::empty();
-		}
-	}
-	
-	public function langDirectoryFinder() : FinderCollection
-	{
-		if ($this->basePathMissing()) {
-			return FinderCollection::empty();
-		}
-		
-		return FinderCollection::forDirectories()
-			->depth(0)
-			->name('lang')
-			->in($this->base_path.'/*/resources/');
-	}
+    public function livewireComponentFileFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
 
-	protected function basePathMissing(): bool
-	{
-		return false === $this->filesystem->isDirectory($this->base_path);
-	}
+        try {
+            return FinderCollection::forFiles()
+                ->name('*.php')
+                ->in($this->base_path . '/*/src/Http/Livewire');
+        } catch (\Exception $e) {
+            return FinderCollection::empty();
+        }
+    }
+
+    public function langDirectoryFinder(): FinderCollection
+    {
+        if ($this->basePathMissing()) {
+            return FinderCollection::empty();
+        }
+
+        return FinderCollection::forDirectories()
+            ->depth(0)
+            ->name('lang')
+            ->in($this->base_path . '/*/resources/');
+    }
+
+    protected function basePathMissing(): bool
+    {
+        return false === $this->filesystem->isDirectory($this->base_path);
+    }
 }

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -7,130 +7,130 @@ use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 
 class AutoDiscoveryHelper
 {
-    /**
-     * @var \InterNACHI\Modular\Support\ModuleRegistry
-     */
-    protected $module_registry;
+	/**
+	 * @var \InterNACHI\Modular\Support\ModuleRegistry
+	 */
+	protected $module_registry;
 
-    /**
-     * @var \Illuminate\Filesystem\Filesystem
-     */
-    protected $filesystem;
+	/**
+	 * @var \Illuminate\Filesystem\Filesystem
+	 */
+	protected $filesystem;
 
-    /**
-     * @var string
-     */
-    protected $base_path;
+	/**
+	 * @var string
+	 */
+	protected $base_path;
 
-    public function __construct(ModuleRegistry $module_registry, Filesystem $filesystem)
-    {
-        $this->module_registry = $module_registry;
-        $this->filesystem = $filesystem;
-        $this->base_path = $module_registry->getModulesPath();
-    }
+	public function __construct(ModuleRegistry $module_registry, Filesystem $filesystem)
+	{
+		$this->module_registry = $module_registry;
+		$this->filesystem = $filesystem;
+		$this->base_path = $module_registry->getModulesPath();
+	}
 
-    public function commandFileFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forFiles()
-                ->name('*.php')
-                ->in($this->base_path . '/*/src/Console/Commands');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function commandFileFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forFiles()
+				->name('*.php')
+				->in($this->base_path . '/*/src/Console/Commands');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function factoryDirectoryFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forDirectories()
-                ->depth(0)
-                ->name('factories')
-                ->in($this->base_path . '/*/database/');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function factoryDirectoryFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forDirectories()
+				->depth(0)
+				->name('factories')
+				->in($this->base_path . '/*/database/');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function migrationDirectoryFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forDirectories()
-                ->depth(0)
-                ->name('migrations')
-                ->in($this->base_path . '/*/database/');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function migrationDirectoryFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forDirectories()
+				->depth(0)
+				->name('migrations')
+				->in($this->base_path . '/*/database/');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function modelFileFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forFiles()
-                ->name('*.php')
-                ->in($this->base_path . '/*/src/Models');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function modelFileFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forFiles()
+				->name('*.php')
+				->in($this->base_path . '/*/src/Models');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function bladeComponentFileFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forFiles()
-                ->name('*.php')
-                ->in($this->base_path . '/*/src/View/Components');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function bladeComponentFileFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forFiles()
+				->name('*.php')
+				->in($this->base_path . '/*/src/View/Components');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function routeFileFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forFiles()
-                ->depth(0)
-                ->name('*.php')
-                ->in($this->base_path . '/*/routes')
-                ->sortByName();
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function routeFileFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forFiles()
+				->depth(0)
+				->name('*.php')
+				->in($this->base_path . '/*/routes')
+				->sortByName();
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function viewDirectoryFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forDirectories()
-                ->depth(0)
-                ->name('views')
-                ->in($this->base_path . '/*/resources/');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function viewDirectoryFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forDirectories()
+				->depth(0)
+				->name('views')
+				->in($this->base_path . '/*/resources/');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function langDirectoryFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forDirectories()
-                ->depth(0)
-                ->name('lang')
-                ->in($this->base_path . '/*/resources/');
-        } catch (DirectoryNotFoundException $exception) {
-            return FinderCollection::empty();
-        }
-    }
+	public function langDirectoryFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forDirectories()
+				->depth(0)
+				->name('lang')
+				->in($this->base_path . '/*/resources/');
+		} catch (DirectoryNotFoundException $exception) {
+			return FinderCollection::empty();
+		}
+	}
 
-    public function livewireComponentFileFinder(): FinderCollection
-    {
-        try {
-            return FinderCollection::forFiles()
-                ->name('*.php')
-                ->in($this->base_path . '/*/src/Http/Livewire');
-        } catch (\Exception $e) {
-            return FinderCollection::empty();
-        }
-    }
+	public function livewireComponentFileFinder(): FinderCollection
+	{
+		try {
+			return FinderCollection::forFiles()
+				->name('*.php')
+				->in($this->base_path . '/*/src/Http/Livewire');
+		} catch (\Exception $e) {
+			return FinderCollection::empty();
+		}
+	}
 }

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -110,20 +110,20 @@ class AutoDiscoveryHelper
 			->in($this->base_path.'/*/resources/');
 	}
 	
-	protected function bootLivewireComponents(): void
-    	{
-        	if (class_exists('Livewire\\Livewire')) {
-		    $this->autoDiscoveryHelper()
-			->livewireComponentFileFinder()
-			->each(function (SplFileInfo $component) {
-			    if (!$module = $this->registry()->moduleForPath($component->getPath())) {
-				throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
-			    }
-			    $componentName = Str::of($component->getBasename('.php'))->kebab();
-			    \Livewire\Livewire::component($module->name . '::' . $componentName, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
-			});
-        	}
-    	}
+	public function livewireComponentFileFinder(): FinderCollection
+	{
+		if ($this->basePathMissing()) {
+		    return FinderCollection::empty();
+		}
+
+		try {
+		    return FinderCollection::forFiles()
+			->name('*.php')
+			->in($this->base_path . '/*/src/Http/Livewire');
+		} catch (\Exception $e) {
+		    return FinderCollection::empty();
+		}
+	}
 	
 	public function langDirectoryFinder() : FinderCollection
 	{

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -110,6 +110,21 @@ class AutoDiscoveryHelper
 			->in($this->base_path.'/*/resources/');
 	}
 	
+	protected function bootLivewireComponents(): void
+    	{
+        	if (class_exists('Livewire\\Livewire')) {
+		    $this->autoDiscoveryHelper()
+			->livewireComponentFileFinder()
+			->each(function (SplFileInfo $component) {
+			    if (!$module = $this->registry()->moduleForPath($component->getPath())) {
+				throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
+			    }
+			    $componentName = Str::of($component->getBasename('.php'))->kebab();
+			    \Livewire\Livewire::component($module->name . '::' . $componentName, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+			});
+        	}
+    	}
+	
 	public function langDirectoryFinder() : FinderCollection
 	{
 		if ($this->basePathMissing()) {

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -3,6 +3,7 @@
 namespace InterNACHI\Modular\Support;
 
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 
 class AutoDiscoveryHelper
 {
@@ -120,7 +121,7 @@ class AutoDiscoveryHelper
 		    return FinderCollection::forFiles()
 			->name('*.php')
 			->in($this->base_path . '/*/src/Http/Livewire');
-		} catch (\Exception $e) {
+		} catch (DirectoryNotFoundException $e) {
 		    return FinderCollection::empty();
 		}
 	}

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -238,14 +238,14 @@ class ModularServiceProvider extends ServiceProvider
 		if (class_exists('Livewire\\Livewire')) {
 			$this->autoDiscoveryHelper()
 				->livewireComponentFileFinder()
-				->each(function (SplFileInfo $component) {
+				->each(function(SplFileInfo $component) {
 					$module = $this->registry()->moduleForPathOrFail($component->getPath());
-					$componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
-						return (string)Str::of($item)->kebab();
-					})->reject(function ($item) {
+					$componentPath = collect(explode('/', $component->getRelativePath()))->map(function($item) {
+						return (string) Str::of($item)->kebab();
+					})->reject(function($item) {
 						return $item == null;
 					})->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
-					\Livewire\Livewire::component($module->name.'::'. $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+					\Livewire\Livewire::component($module->name.'::'.$componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
 				});
 		}
 	}

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -196,6 +196,21 @@ class ModularServiceProvider extends ServiceProvider
 		});
 	}
 	
+	protected function bootLivewireComponents(): void
+    	{
+		if (class_exists('Livewire\\Livewire')) {
+		    $this->autoDiscoveryHelper()
+			->livewireComponentFileFinder()
+			->each(function (SplFileInfo $component) {
+			    if (!$module = $this->registry()->moduleForPath($component->getPath())) {
+				throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
+			    }
+			    $componentName = Str::of($component->getBasename('.php'))->kebab();
+			    \Livewire\Livewire::component($module->name . '::' . $componentName, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+			});
+		}
+    	}
+	
 	protected function bootTranslations() : void
 	{
 		$this->callAfterResolving('translator', function(TranslatorContract $translator) {

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -30,378 +30,385 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class ModularServiceProvider extends ServiceProvider
 {
-	/**
-	 * @var \InterNACHI\Modular\Support\ModuleRegistry
-	 */
-	protected $registry;
-	
-	/**
-	 * @var \InterNACHI\Modular\Support\AutoDiscoveryHelper
-	 */
-	protected $auto_discovery_helper;
-	
-	/**
-	 * This is the base directory of the modular package
-	 *
-	 * @var string
-	 */
-	protected $base_dir;
-	
-	/**
-	 * This is the configured modules directory (app-modules/ by default)
-	 * 
-	 * @var string 
-	 */
-	protected $modules_path;
-	
-	public function __construct($app)
-	{
-		parent::__construct($app);
-		
-		$this->base_dir = dirname(__DIR__, 2);
-	}
-	
-	public function register(): void
-	{
-		$this->mergeConfigFrom("{$this->base_dir}/config.php", 'app-modules');
-		
-		$this->app->singleton(ModuleRegistry::class, function() {
-			return new ModuleRegistry(
-				$this->getModulesBasePath(),
-				$this->app->bootstrapPath('cache/modules.php')
-			);
-		});
-		
-		$this->app->singleton(AutoDiscoveryHelper::class, function($app) {
-			return new AutoDiscoveryHelper(
-				$app->make(ModuleRegistry::class),
-				$app->make(Filesystem::class)
-			);
-		});
-		
-		$this->app->singleton(MakeMigration::class, function($app) {
-			return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
-		});
-		
-		// Set up lazy registrations for things that only need to run if we're using
-		// that functionality (e.g. we only need to look for and register migrations
-		// if we're running the migrator)
-		$this->registerLazily(Migrator::class, [$this, 'registerMigrations']);
-		$this->registerLazily(Gate::class, [$this, 'registerPolicies']);
-		$this->registerLazily(LegacyEloquentFactory::class, [$this, 'registerLegacyFactories']);
-		
-		// If we're running Laravel 8 or higher, set up the Eloquent Factory to resolve
-		// module factories as well as App factories.
-		if (class_exists(EloquentFactory::class)) {
-			$this->registerEloquentFactories();
-		}
-		
-		// Look for and register all our commands in the CLI context
-		Artisan::starting(Closure::fromCallable([$this, 'registerCommands']));
-	}
-	
-	public function boot(): void
-	{
-		$this->publishVendorFiles();
-		$this->bootPackageCommands();
-		
-		$this->bootRoutes();
-		$this->bootBreadcrumbs();
-		$this->bootViews();
-		$this->bootBladeComponents();
-		$this->bootTranslations();
-	}
-	
-	protected function registry(): ModuleRegistry
-	{
-		if (null === $this->registry) {
-			$this->registry = $this->app->make(ModuleRegistry::class);
-		}
-		
-		return $this->registry;
-	}
-	
-	protected function autoDiscoveryHelper(): AutoDiscoveryHelper
-	{
-		if (null === $this->auto_discovery_helper) {
-			$this->auto_discovery_helper = $this->app->make(AutoDiscoveryHelper::class);
-		}
-		
-		return $this->auto_discovery_helper;
-	}
-	
-	protected function publishVendorFiles(): void
-	{
-		$this->publishes([
-			"{$this->base_dir}/config.php" => $this->app->configPath('app-modules.php'),
-		], 'modular-config');
-	}
-	
-	protected function bootPackageCommands(): void 
-	{
-		if (!$this->app->runningInConsole()) {
-			return;
-		}
-		
-		$this->commands([
-			MakeModule::class,
-			ModulesCache::class,
-			ModulesClear::class,
-			ModulesSync::class,
-			ModulesList::class,
-		]);
-	}
-	
-	protected function bootRoutes(): void
-	{
-		if ($this->app->routesAreCached()) {
-			return;
-		}
-		
-		$this->autoDiscoveryHelper()
-			->routeFileFinder()
-			->each(function(SplFileInfo $file) {
-				require $file->getRealPath();
-			});
-	}
-	
-	protected function bootViews(): void
-	{
-		$this->callAfterResolving('view', function(ViewFactory $view_factory) {
-			$this->autoDiscoveryHelper()
-				->viewDirectoryFinder()
-				->each(function(SplFileInfo $directory) use ($view_factory) {
-					if (!$module = $this->registry()->moduleForPath($directory->getPath())) {
-						throw new RuntimeException("Unable to determine module for '{$directory->getPath()}'");
-					}
-					
-					$view_factory->addNamespace($module->name, $directory->getRealPath());
-				});
-		});
-	}
-	
-	protected function bootBladeComponents() : void
-	{
-		$this->callAfterResolving(BladeCompiler::class, function(BladeCompiler $blade) {
-			$this->autoDiscoveryHelper()
-				->bladeComponentFileFinder()
-				->each(function(SplFileInfo $component) use ($blade) {
-					if (!$module = $this->registry()->moduleForPath($component->getPath())) {
-						throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
-					}
-					
-					$fully_qualified_component = $this->pathToFullyQualifiedClassName($component->getPathname(), $module);
-					$blade->component($fully_qualified_component, null, $module->name);
-				});
-		});
-	}
-	
-	protected function bootLivewireComponents(): void
-    	{
-		if (class_exists('Livewire\\Livewire')) {
-		    $this->autoDiscoveryHelper()
-			->livewireComponentFileFinder()
-			->each(function (SplFileInfo $component) {
-			    $module = $this->registry()->moduleForPathOrFail($component->getPath());
-			    $componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
-				return (string)Str::of($item)->kebab();
-			    })->reject(function ($item) {
-				return $item == null;
-			    })->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
-			    \Livewire\Livewire::component($module->name . '::' . $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
-			});
-		}
-    	}
-	
-	protected function bootTranslations() : void
-	{
-		$this->callAfterResolving('translator', function(TranslatorContract $translator) {
-			if (!$translator instanceof Translator) {
-				return;
-			}
-			
-			$this->autoDiscoveryHelper()
-				->langDirectoryFinder()
-				->each(function(SplFileInfo $directory) use ($translator) {
-					if (!$module = $this->registry()->moduleForPath($directory->getPath())) {
-						throw new RuntimeException("Unable to determine module for '{$directory->getPath()}'");
-					}
-					
-					$path = $directory->getRealPath();
-					
-					$translator->addNamespace($module->name, $path);
-					$translator->addJsonPath($path);
-				});
-		});
-	}
-	
-	/**
-	 * This functionality is likely to go away at some point so don't rely
-	 * on it too much. The package has been abandoned.
-	 */
-	protected function bootBreadcrumbs() : void
-	{
-		$class_name = 'Diglactic\\Breadcrumbs\\Manager';
-		
-		if (!class_exists($class_name)) {
-			return;
-		}
-		
-		// The breadcrumbs package makes $breadcrumbs available in the scope of breadcrumb
-		// files, so we'll do the same for consistency-sake
-		$breadcrumbs = $this->app->make($class_name);
-		
-		$files = glob($this->getModulesBasePath().'/*/routes/breadcrumbs/*.php');
-		
-		foreach ($files as $file) {
-			require_once $file;
-		}
-	}
-	
-	protected function registerMigrations(Migrator $migrator) : void
-	{
-		$this->autoDiscoveryHelper()
-			->migrationDirectoryFinder()
-			->each(function(SplFileInfo $path) use ($migrator) {
-				$migrator->path($path->getRealPath());
-			});
-	}
-	
-	protected function registerEloquentFactories() : void
-	{
-		EloquentFactory::guessFactoryNamesUsing(function($model_name) {
-			// Because Factory::$namespace is protected, we need to access it via reflection.
-			// Hopefully we can PR something into Laravel to make this less hacky.
-			$reflection = new ReflectionProperty(EloquentFactory::class, 'namespace');
-			$reflection->setAccessible(true);
-			$factory_namespace = $reflection->getValue();
-			
-			$modules_namespace = config('app-modules.modules_namespace', 'Modules');
-			
-			if (
-				Str::startsWith($model_name, $modules_namespace)
-				&& $module = $this->registry()->moduleForClass($model_name)
-			) {
-				$model_name = Str::startsWith($model_name, $module->qualify('Models\\'))
-					? Str::after($model_name, $module->qualify('Models\\'))
-					: Str::after($model_name, $module->namespace());
-				
-				return $module->qualify($factory_namespace.$model_name.'Factory');
-			}
-			
-			$model_name = Str::startsWith($model_name, 'App\\Models\\')
-				? Str::after($model_name, 'App\\Models\\')
-				: Str::after($model_name, 'App\\');
-			
-			return $factory_namespace.$model_name.'Factory';
-		});
-	}
-	
-	protected function registerLegacyFactories(LegacyEloquentFactory $factory) : void
-	{
-		$this->autoDiscoveryHelper()
-			->factoryDirectoryFinder()
-			->each(function(SplFileInfo $path) use ($factory) {
-				$factory->load($path->getRealPath());
-			});
-	}
-	
-	protected function registerPolicies(Gate $gate) : void
-	{
-		$this->autoDiscoveryHelper()
-			->modelFileFinder()
-			->each(function(SplFileInfo $file) use ($gate) {
-				if (!$module = $this->registry()->moduleForPath($file->getPath())) {
-					throw new RuntimeException("Unable to determine module for '{$file->getPath()}'");
-				}
-				
-				$fully_qualified_model = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
-				
-				// First, check for a policy that maps to the full namespace of the model
-				// i.e. Models/Foo/Bar -> Policies/Foo/BarPolicy
-				$namespaced_model = Str::after($fully_qualified_model, 'Models\\');
-				$namespaced_policy = rtrim($module->namespaces->first(), '\\').'\\Policies\\'.$namespaced_model.'Policy';
-				if (class_exists($namespaced_policy)) {
-					$gate->policy($fully_qualified_model, $namespaced_policy);
-				}
-				
-				// If that doesn't match, try the simple mapping as well
-				// i.e. Models/Foo/Bar -> Policies/BarPolicy
-				if (false !== strpos($namespaced_model, '\\')) {
-					$simple_model = Str::afterLast($fully_qualified_model, '\\');
-					$simple_policy = rtrim($module->namespaces->first(), '\\').'\\Policies\\'.$simple_model.'Policy';
-					
-					if (class_exists($simple_policy)) {
-						$gate->policy($fully_qualified_model, $simple_policy);
-					}
-				}
-			});
-	}
-	
-	protected function registerCommands(Artisan $artisan): void
-	{
-		$this->autoDiscoveryHelper()
-			->commandFileFinder()
-			->each(function(SplFileInfo $file) use ($artisan) {
-				if (!$module = $this->registry()->moduleForPath($file->getPath())) {
-					throw new RuntimeException("Unable to determine module for '{$file->getPath()}'");
-				}
-				
-				$class_name = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
-				if ($this->isInstantiableCommand($class_name)) {
-					$artisan->resolve($class_name);
-				}
-			});
-	}
-	
-	protected function registerLazily(string $class_name, callable $callback): self
-	{
-		$this->app->resolving($class_name, Closure::fromCallable($callback));
-		
-		return $this;
-	}
-	
-	protected function getModulesBasePath() : string
-	{
-		if (null === $this->modules_path) {
-			$directory_name = $this->app->make('config')->get('app-modules.modules_directory', 'app-modules');
-			$this->modules_path = $this->app->basePath($directory_name);
-		}
-		
-		return $this->modules_path;
-	}
-	
-	protected function pathToFullyQualifiedClassName($path, ModuleConfig $module_config) : string
-	{
-		foreach ($module_config->namespaces as $namespace_path => $namespace) {
-			if (0 === strpos($path, $namespace_path)) {
-				$relative_path = Str::after($path, $namespace_path);
-				return $namespace.$this->formatPathAsNamespace($relative_path);
-			}
-		}
-		
-		throw new RuntimeException("Unable to infer qualified class name for '{$path}'");
-	}
-	
-	protected function formatPathAsNamespace(string $path) : string
-	{
-		$path = trim($path, DIRECTORY_SEPARATOR);
-		
-		$replacements = [
-			'/' => '\\',
-			'.php' => '',
-		];
-		
-		return str_replace(
-			array_keys($replacements),
-			array_values($replacements),
-			$path
-		);
-	}
-	
-	protected function isInstantiableCommand($command) : bool
-	{
-		return is_subclass_of($command, Command::class)
-			&& !(new ReflectionClass($command))->isAbstract();
-	}
+    /**
+     * @var \InterNACHI\Modular\Support\ModuleRegistry
+     */
+    protected $registry;
+
+    /**
+     * @var \InterNACHI\Modular\Support\AutoDiscoveryHelper
+     */
+    protected $auto_discovery_helper;
+
+    /**
+     * This is the base directory of the modular package
+     *
+     * @var string
+     */
+    protected $base_dir;
+
+    /**
+     * This is the configured modules directory (app-modules/ by default)
+     * 
+     * @var string 
+     */
+    protected $modules_path;
+
+    public function __construct($app)
+    {
+        parent::__construct($app);
+
+        $this->base_dir = dirname(__DIR__, 2);
+    }
+
+    public function register(): void
+    {
+        $this->mergeConfigFrom("{$this->base_dir}/config.php", 'app-modules');
+
+        $this->app->singleton(ModuleRegistry::class, function () {
+            return new ModuleRegistry(
+                $this->getModulesBasePath(),
+                $this->app->bootstrapPath('cache/modules.php')
+            );
+        });
+
+        $this->app->singleton(AutoDiscoveryHelper::class, function ($app) {
+            return new AutoDiscoveryHelper(
+                $app->make(ModuleRegistry::class),
+                $app->make(Filesystem::class)
+            );
+        });
+
+        $this->app->singleton(MakeMigration::class, function ($app) {
+            return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
+        });
+
+        // Set up lazy registrations for things that only need to run if we're using
+        // that functionality (e.g. we only need to look for and register migrations
+        // if we're running the migrator)
+        $this->registerLazily(Migrator::class, [$this, 'registerMigrations']);
+        $this->registerLazily(Gate::class, [$this, 'registerPolicies']);
+        $this->registerLazily(LegacyEloquentFactory::class, [$this, 'registerLegacyFactories']);
+
+        // If we're running Laravel 8 or higher, set up the Eloquent Factory to resolve
+        // module factories as well as App factories.
+        if (class_exists(EloquentFactory::class)) {
+            $this->registerEloquentFactories();
+        }
+
+        // Look for and register all our commands in the CLI context
+        Artisan::starting(Closure::fromCallable([$this, 'registerCommands']));
+    }
+
+    public function boot(): void
+    {
+        $this->publishVendorFiles();
+        $this->bootPackageCommands();
+
+        $this->bootRoutes();
+        $this->bootBreadcrumbs();
+        $this->bootViews();
+        $this->bootBladeComponents();
+        $this->bootTranslations();
+        $this->bootLivewireComponents();
+    }
+
+    protected function registry(): ModuleRegistry
+    {
+        if (null === $this->registry) {
+            $this->registry = $this->app->make(ModuleRegistry::class);
+        }
+
+        return $this->registry;
+    }
+
+    protected function autoDiscoveryHelper(): AutoDiscoveryHelper
+    {
+        if (null === $this->auto_discovery_helper) {
+            $this->auto_discovery_helper = $this->app->make(AutoDiscoveryHelper::class);
+        }
+
+        return $this->auto_discovery_helper;
+    }
+
+    protected function publishVendorFiles(): void
+    {
+        $this->publishes([
+            "{$this->base_dir}/config.php" => $this->app->configPath('app-modules.php'),
+        ], 'modular-config');
+    }
+
+    protected function bootPackageCommands(): void
+    {
+        if (!$this->app->runningInConsole()) {
+            return;
+        }
+
+        $this->commands([
+            MakeModule::class,
+            ModulesCache::class,
+            ModulesClear::class,
+            ModulesSync::class,
+            ModulesList::class,
+        ]);
+    }
+
+    protected function bootRoutes(): void
+    {
+        if ($this->app->routesAreCached()) {
+            return;
+        }
+
+        $this->autoDiscoveryHelper()
+            ->routeFileFinder()
+            ->each(function (SplFileInfo $file) {
+                require $file->getRealPath();
+            });
+    }
+
+    protected function bootViews(): void
+    {
+        $this->callAfterResolving('view', function (ViewFactory $view_factory) {
+            $this->autoDiscoveryHelper()
+                ->viewDirectoryFinder()
+                ->each(function (SplFileInfo $directory) use ($view_factory) {
+                    if (!$module = $this->registry()->moduleForPath($directory->getPath())) {
+                        throw new RuntimeException("Unable to determine module for '{$directory->getPath()}'");
+                    }
+
+                    $view_factory->addNamespace($module->name, $directory->getRealPath());
+                });
+        });
+    }
+
+    protected function bootBladeComponents(): void
+    {
+        $this->callAfterResolving(BladeCompiler::class, function (BladeCompiler $blade) {
+            $this->autoDiscoveryHelper()
+                ->bladeComponentFileFinder()
+                ->each(function (SplFileInfo $component) use ($blade) {
+                    if (!$module = $this->registry()->moduleForPath($component->getPath())) {
+                        throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
+                    }
+
+                    $fully_qualified_component = $this->pathToFullyQualifiedClassName($component->getPathname(), $module);
+                    $blade->component($fully_qualified_component, null, $module->name);
+                });
+        });
+    }
+
+    protected function bootLivewireComponents(): void
+    {
+
+        if (class_exists('Livewire\\Livewire')) {
+            $this->autoDiscoveryHelper()
+                ->livewireComponentFileFinder()
+                ->each(function (SplFileInfo $component) {
+                    if (!$module = $this->registry()->moduleForPath($component->getPath())) {
+                        throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
+                    }
+
+                    $componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
+                        return (string)Str::of($item)->kebab();
+                    })->reject(function ($item) {
+                        return $item == null;
+                    })->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
+
+
+                    \Livewire\Livewire::component($module->name . '::' . $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+                });
+        }
+    }
+
+    protected function bootTranslations(): void
+    {
+        $this->callAfterResolving('translator', function (TranslatorContract $translator) {
+            if (!$translator instanceof Translator) {
+                return;
+            }
+
+            $this->autoDiscoveryHelper()
+                ->langDirectoryFinder()
+                ->each(function (SplFileInfo $directory) use ($translator) {
+                    if (!$module = $this->registry()->moduleForPath($directory->getPath())) {
+                        throw new RuntimeException("Unable to determine module for '{$directory->getPath()}'");
+                    }
+
+                    $path = $directory->getRealPath();
+
+                    $translator->addNamespace($module->name, $path);
+                    $translator->addJsonPath($path);
+                });
+        });
+    }
+
+    /**
+     * This functionality is likely to go away at some point so don't rely
+     * on it too much. The package has been abandoned.
+     */
+    protected function bootBreadcrumbs(): void
+    {
+        $class_name = 'Diglactic\\Breadcrumbs\\Manager';
+
+        if (!class_exists($class_name)) {
+            return;
+        }
+
+        // The breadcrumbs package makes $breadcrumbs available in the scope of breadcrumb
+        // files, so we'll do the same for consistency-sake
+        $breadcrumbs = $this->app->make($class_name);
+
+        $files = glob($this->getModulesBasePath() . '/*/routes/breadcrumbs/*.php');
+
+        foreach ($files as $file) {
+            require_once $file;
+        }
+    }
+
+    protected function registerMigrations(Migrator $migrator): void
+    {
+        $this->autoDiscoveryHelper()
+            ->migrationDirectoryFinder()
+            ->each(function (SplFileInfo $path) use ($migrator) {
+                $migrator->path($path->getRealPath());
+            });
+    }
+
+    protected function registerEloquentFactories(): void
+    {
+        EloquentFactory::guessFactoryNamesUsing(function ($model_name) {
+            // Because Factory::$namespace is protected, we need to access it via reflection.
+            // Hopefully we can PR something into Laravel to make this less hacky.
+            $reflection = new ReflectionProperty(EloquentFactory::class, 'namespace');
+            $reflection->setAccessible(true);
+            $factory_namespace = $reflection->getValue();
+
+            $modules_namespace = config('app-modules.modules_namespace', 'Modules');
+
+            if (
+                Str::startsWith($model_name, $modules_namespace)
+                && $module = $this->registry()->moduleForClass($model_name)
+            ) {
+                $model_name = Str::startsWith($model_name, $module->qualify('Models\\'))
+                    ? Str::after($model_name, $module->qualify('Models\\'))
+                    : Str::after($model_name, $module->namespace());
+
+                return $module->qualify($factory_namespace . $model_name . 'Factory');
+            }
+
+            $model_name = Str::startsWith($model_name, 'App\\Models\\')
+                ? Str::after($model_name, 'App\\Models\\')
+                : Str::after($model_name, 'App\\');
+
+            return $factory_namespace . $model_name . 'Factory';
+        });
+    }
+
+    protected function registerLegacyFactories(LegacyEloquentFactory $factory): void
+    {
+        $this->autoDiscoveryHelper()
+            ->factoryDirectoryFinder()
+            ->each(function (SplFileInfo $path) use ($factory) {
+                $factory->load($path->getRealPath());
+            });
+    }
+
+    protected function registerPolicies(Gate $gate): void
+    {
+        $this->autoDiscoveryHelper()
+            ->modelFileFinder()
+            ->each(function (SplFileInfo $file) use ($gate) {
+                if (!$module = $this->registry()->moduleForPath($file->getPath())) {
+                    throw new RuntimeException("Unable to determine module for '{$file->getPath()}'");
+                }
+
+                $fully_qualified_model = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
+
+                // First, check for a policy that maps to the full namespace of the model
+                // i.e. Models/Foo/Bar -> Policies/Foo/BarPolicy
+                $namespaced_model = Str::after($fully_qualified_model, 'Models\\');
+                $namespaced_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $namespaced_model . 'Policy';
+                if (class_exists($namespaced_policy)) {
+                    $gate->policy($fully_qualified_model, $namespaced_policy);
+                }
+
+                // If that doesn't match, try the simple mapping as well
+                // i.e. Models/Foo/Bar -> Policies/BarPolicy
+                if (false !== strpos($namespaced_model, '\\')) {
+                    $simple_model = Str::afterLast($fully_qualified_model, '\\');
+                    $simple_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $simple_model . 'Policy';
+
+                    if (class_exists($simple_policy)) {
+                        $gate->policy($fully_qualified_model, $simple_policy);
+                    }
+                }
+            });
+    }
+
+    protected function registerCommands(Artisan $artisan): void
+    {
+        $this->autoDiscoveryHelper()
+            ->commandFileFinder()
+            ->each(function (SplFileInfo $file) use ($artisan) {
+                if (!$module = $this->registry()->moduleForPath($file->getPath())) {
+                    throw new RuntimeException("Unable to determine module for '{$file->getPath()}'");
+                }
+
+                $class_name = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
+                if ($this->isInstantiableCommand($class_name)) {
+                    $artisan->resolve($class_name);
+                }
+            });
+    }
+
+    protected function registerLazily(string $class_name, callable $callback): self
+    {
+        $this->app->resolving($class_name, Closure::fromCallable($callback));
+
+        return $this;
+    }
+
+    protected function getModulesBasePath(): string
+    {
+        if (null === $this->modules_path) {
+            $directory_name = $this->app->make('config')->get('app-modules.modules_directory', 'app-modules');
+            $this->modules_path = $this->app->basePath($directory_name);
+        }
+
+        return $this->modules_path;
+    }
+
+    protected function pathToFullyQualifiedClassName($path, ModuleConfig $module_config): string
+    {
+        foreach ($module_config->namespaces as $namespace_path => $namespace) {
+            if (0 === strpos($path, $namespace_path)) {
+                $relative_path = Str::after($path, $namespace_path);
+                return $namespace . $this->formatPathAsNamespace($relative_path);
+            }
+        }
+
+        throw new RuntimeException("Unable to infer qualified class name for '{$path}'");
+    }
+
+    protected function formatPathAsNamespace(string $path): string
+    {
+        $path = trim($path, DIRECTORY_SEPARATOR);
+
+        $replacements = [
+            '/' => '\\',
+            '.php' => '',
+        ];
+
+        return str_replace(
+            array_keys($replacements),
+            array_values($replacements),
+            $path
+        );
+    }
+
+    protected function isInstantiableCommand($command): bool
+    {
+        return is_subclass_of($command, Command::class)
+            && !(new ReflectionClass($command))->isAbstract();
+    }
 }

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -202,9 +202,7 @@ class ModularServiceProvider extends ServiceProvider
 		    $this->autoDiscoveryHelper()
 			->livewireComponentFileFinder()
 			->each(function (SplFileInfo $component) {
-			    if (!$module = $this->registry()->moduleForPath($component->getPath())) {
-				throw new RuntimeException("Unable to determine module for '{$component->getPath()}'");
-			    }
+			    $module = $this->registry()->moduleForPathOrFail($component->getPath());
 			    $componentName = Str::of($component->getBasename('.php'))->kebab();
 			    \Livewire\Livewire::component($module->name . '::' . $componentName, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
 			});

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -34,77 +34,77 @@ class ModularServiceProvider extends ServiceProvider
 	 * @var \InterNACHI\Modular\Support\ModuleRegistry
 	 */
 	protected $registry;
-
+	
 	/**
 	 * @var \InterNACHI\Modular\Support\AutoDiscoveryHelper
 	 */
 	protected $auto_discovery_helper;
-
+	
 	/**
 	 * This is the base directory of the modular package
 	 *
 	 * @var string
 	 */
 	protected $base_dir;
-
+	
 	/**
 	 * This is the configured modules directory (app-modules/ by default)
 	 * 
 	 * @var string 
 	 */
 	protected $modules_path;
-
+	
 	public function __construct($app)
 	{
 		parent::__construct($app);
-
+		
 		$this->base_dir = dirname(__DIR__, 2);
 	}
-
+	
 	public function register(): void
 	{
 		$this->mergeConfigFrom("{$this->base_dir}/config.php", 'app-modules');
-
-		$this->app->singleton(ModuleRegistry::class, function () {
+		
+		$this->app->singleton(ModuleRegistry::class, function() {
 			return new ModuleRegistry(
 				$this->getModulesBasePath(),
 				$this->app->bootstrapPath('cache/modules.php')
 			);
 		});
-
-		$this->app->singleton(AutoDiscoveryHelper::class, function ($app) {
+		
+		$this->app->singleton(AutoDiscoveryHelper::class, function($app) {
 			return new AutoDiscoveryHelper(
 				$app->make(ModuleRegistry::class),
 				$app->make(Filesystem::class)
 			);
 		});
-
-		$this->app->singleton(MakeMigration::class, function ($app) {
+		
+		$this->app->singleton(MakeMigration::class, function($app) {
 			return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
 		});
-
+		
 		// Set up lazy registrations for things that only need to run if we're using
 		// that functionality (e.g. we only need to look for and register migrations
 		// if we're running the migrator)
 		$this->registerLazily(Migrator::class, [$this, 'registerMigrations']);
 		$this->registerLazily(Gate::class, [$this, 'registerPolicies']);
 		$this->registerLazily(LegacyEloquentFactory::class, [$this, 'registerLegacyFactories']);
-
+		
 		// If we're running Laravel 8 or higher, set up the Eloquent Factory to resolve
 		// module factories as well as App factories.
 		if (class_exists(EloquentFactory::class)) {
 			$this->registerEloquentFactories();
 		}
-
+		
 		// Look for and register all our commands in the CLI context
 		Artisan::starting(Closure::fromCallable([$this, 'registerCommands']));
 	}
-
+	
 	public function boot(): void
 	{
 		$this->publishVendorFiles();
 		$this->bootPackageCommands();
-
+		
 		$this->bootRoutes();
 		$this->bootBreadcrumbs();
 		$this->bootViews();
@@ -112,38 +112,38 @@ class ModularServiceProvider extends ServiceProvider
 		$this->bootTranslations();
 		$this->bootLivewireComponents();
 	}
-
+	
 	protected function registry(): ModuleRegistry
 	{
 		if (null === $this->registry) {
 			$this->registry = $this->app->make(ModuleRegistry::class);
 		}
-
+		
 		return $this->registry;
 	}
-
+	
 	protected function autoDiscoveryHelper(): AutoDiscoveryHelper
 	{
 		if (null === $this->auto_discovery_helper) {
 			$this->auto_discovery_helper = $this->app->make(AutoDiscoveryHelper::class);
 		}
-
+		
 		return $this->auto_discovery_helper;
 	}
-
+	
 	protected function publishVendorFiles(): void
 	{
 		$this->publishes([
 			"{$this->base_dir}/config.php" => $this->app->configPath('app-modules.php'),
 		], 'modular-config');
 	}
-
-	protected function bootPackageCommands(): void
+	
+	protected function bootPackageCommands(): void 
 	{
 		if (!$this->app->runningInConsole()) {
 			return;
 		}
-
+		
 		$this->commands([
 			MakeModule::class,
 			ModulesCache::class,
@@ -152,82 +152,82 @@ class ModularServiceProvider extends ServiceProvider
 			ModulesList::class,
 		]);
 	}
-
+	
 	protected function bootRoutes(): void
 	{
 		if ($this->app->routesAreCached()) {
 			return;
 		}
-
+		
 		$this->autoDiscoveryHelper()
 			->routeFileFinder()
-			->each(function (SplFileInfo $file) {
+			->each(function(SplFileInfo $file) {
 				require $file->getRealPath();
 			});
 	}
-
+	
 	protected function bootViews(): void
 	{
-		$this->callAfterResolving('view', function (ViewFactory $view_factory) {
+		$this->callAfterResolving('view', function(ViewFactory $view_factory) {
 			$this->autoDiscoveryHelper()
 				->viewDirectoryFinder()
-				->each(function (SplFileInfo $directory) use ($view_factory) {
+				->each(function(SplFileInfo $directory) use ($view_factory) {
 					$module = $this->registry()->moduleForPathOrFail($directory->getPath());
 					$view_factory->addNamespace($module->name, $directory->getRealPath());
 				});
 		});
 	}
-
-	protected function bootBladeComponents(): void
+	
+	protected function bootBladeComponents() : void
 	{
-		$this->callAfterResolving(BladeCompiler::class, function (BladeCompiler $blade) {
+		$this->callAfterResolving(BladeCompiler::class, function(BladeCompiler $blade) {
 			$this->autoDiscoveryHelper()
 				->bladeComponentFileFinder()
-				->each(function (SplFileInfo $component) use ($blade) {
+				->each(function(SplFileInfo $component) use ($blade) {
 					$module = $this->registry()->moduleForPathOrFail($component->getPath());
 					$fully_qualified_component = $this->pathToFullyQualifiedClassName($component->getPathname(), $module);
 					$blade->component($fully_qualified_component, null, $module->name);
 				});
 		});
 	}
-
-	protected function bootTranslations(): void
+	
+	protected function bootTranslations() : void
 	{
-		$this->callAfterResolving('translator', function (TranslatorContract $translator) {
+		$this->callAfterResolving('translator', function(TranslatorContract $translator) {
 			if (!$translator instanceof Translator) {
 				return;
 			}
-
+			
 			$this->autoDiscoveryHelper()
 				->langDirectoryFinder()
-				->each(function (SplFileInfo $directory) use ($translator) {
+				->each(function(SplFileInfo $directory) use ($translator) {
 					$module = $this->registry()->moduleForPathOrFail($directory->getPath());
 					$path = $directory->getRealPath();
-
+					
 					$translator->addNamespace($module->name, $path);
 					$translator->addJsonPath($path);
 				});
 		});
 	}
-
+	
 	/**
 	 * This functionality is likely to go away at some point so don't rely
 	 * on it too much. The package has been abandoned.
 	 */
-	protected function bootBreadcrumbs(): void
+	protected function bootBreadcrumbs() : void
 	{
 		$class_name = 'Diglactic\\Breadcrumbs\\Manager';
-
+		
 		if (!class_exists($class_name)) {
 			return;
 		}
-
+		
 		// The breadcrumbs package makes $breadcrumbs available in the scope of breadcrumb
 		// files, so we'll do the same for consistency-sake
 		$breadcrumbs = $this->app->make($class_name);
-
-		$files = glob($this->getModulesBasePath() . '/*/routes/breadcrumbs/*.php');
-
+		
+		$files = glob($this->getModulesBasePath().'/*/routes/breadcrumbs/*.php');
+		
 		foreach ($files as $file) {
 			require_once $file;
 		}
@@ -236,45 +236,40 @@ class ModularServiceProvider extends ServiceProvider
 	protected function bootLivewireComponents(): void
 	{
 		if (class_exists('Livewire\\Livewire')) {
-
 			$this->autoDiscoveryHelper()
 				->livewireComponentFileFinder()
 				->each(function (SplFileInfo $component) {
-
 					$module = $this->registry()->moduleForPathOrFail($component->getPath());
-
 					$componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
 						return (string)Str::of($item)->kebab();
 					})->reject(function ($item) {
 						return $item == null;
 					})->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
-
-
-					\Livewire\Livewire::component($module->name . '::' . $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+					\Livewire\Livewire::component($module->name.'::'. $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
 				});
 		}
 	}
-
-	protected function registerMigrations(Migrator $migrator): void
+	
+	protected function registerMigrations(Migrator $migrator) : void
 	{
 		$this->autoDiscoveryHelper()
 			->migrationDirectoryFinder()
-			->each(function (SplFileInfo $path) use ($migrator) {
+			->each(function(SplFileInfo $path) use ($migrator) {
 				$migrator->path($path->getRealPath());
 			});
 	}
-
-	protected function registerEloquentFactories(): void
+	
+	protected function registerEloquentFactories() : void
 	{
-		EloquentFactory::guessFactoryNamesUsing(function ($model_name) {
+		EloquentFactory::guessFactoryNamesUsing(function($model_name) {
 			// Because Factory::$namespace is protected, we need to access it via reflection.
 			// Hopefully we can PR something into Laravel to make this less hacky.
 			$reflection = new ReflectionProperty(EloquentFactory::class, 'namespace');
 			$reflection->setAccessible(true);
 			$factory_namespace = $reflection->getValue();
-
+			
 			$modules_namespace = config('app-modules.modules_namespace', 'Modules');
-
+			
 			if (
 				Str::startsWith($model_name, $modules_namespace)
 				&& $module = $this->registry()->moduleForClass($model_name)
@@ -282,61 +277,61 @@ class ModularServiceProvider extends ServiceProvider
 				$model_name = Str::startsWith($model_name, $module->qualify('Models\\'))
 					? Str::after($model_name, $module->qualify('Models\\'))
 					: Str::after($model_name, $module->namespace());
-
-				return $module->qualify($factory_namespace . $model_name . 'Factory');
+				
+				return $module->qualify($factory_namespace.$model_name.'Factory');
 			}
-
+			
 			$model_name = Str::startsWith($model_name, 'App\\Models\\')
 				? Str::after($model_name, 'App\\Models\\')
 				: Str::after($model_name, 'App\\');
-
-			return $factory_namespace . $model_name . 'Factory';
+			
+			return $factory_namespace.$model_name.'Factory';
 		});
 	}
-
-	protected function registerLegacyFactories(LegacyEloquentFactory $factory): void
+	
+	protected function registerLegacyFactories(LegacyEloquentFactory $factory) : void
 	{
 		$this->autoDiscoveryHelper()
 			->factoryDirectoryFinder()
-			->each(function (SplFileInfo $path) use ($factory) {
+			->each(function(SplFileInfo $path) use ($factory) {
 				$factory->load($path->getRealPath());
 			});
 	}
-
-	protected function registerPolicies(Gate $gate): void
+	
+	protected function registerPolicies(Gate $gate) : void
 	{
 		$this->autoDiscoveryHelper()
 			->modelFileFinder()
-			->each(function (SplFileInfo $file) use ($gate) {
+			->each(function(SplFileInfo $file) use ($gate) {
 				$module = $this->registry()->moduleForPathOrFail($file->getPath());
 				$fully_qualified_model = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
-
+				
 				// First, check for a policy that maps to the full namespace of the model
 				// i.e. Models/Foo/Bar -> Policies/Foo/BarPolicy
 				$namespaced_model = Str::after($fully_qualified_model, 'Models\\');
-				$namespaced_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $namespaced_model . 'Policy';
+				$namespaced_policy = rtrim($module->namespaces->first(), '\\').'\\Policies\\'.$namespaced_model.'Policy';
 				if (class_exists($namespaced_policy)) {
 					$gate->policy($fully_qualified_model, $namespaced_policy);
 				}
-
+				
 				// If that doesn't match, try the simple mapping as well
 				// i.e. Models/Foo/Bar -> Policies/BarPolicy
 				if (false !== strpos($namespaced_model, '\\')) {
 					$simple_model = Str::afterLast($fully_qualified_model, '\\');
-					$simple_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $simple_model . 'Policy';
-
+					$simple_policy = rtrim($module->namespaces->first(), '\\').'\\Policies\\'.$simple_model.'Policy';
+					
 					if (class_exists($simple_policy)) {
 						$gate->policy($fully_qualified_model, $simple_policy);
 					}
 				}
 			});
 	}
-
+	
 	protected function registerCommands(Artisan $artisan): void
 	{
 		$this->autoDiscoveryHelper()
 			->commandFileFinder()
-			->each(function (SplFileInfo $file) use ($artisan) {
+			->each(function(SplFileInfo $file) use ($artisan) {
 				$module = $this->registry()->moduleForPathOrFail($file->getPath());
 				$class_name = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
 				if ($this->isInstantiableCommand($class_name)) {
@@ -344,53 +339,53 @@ class ModularServiceProvider extends ServiceProvider
 				}
 			});
 	}
-
+	
 	protected function registerLazily(string $class_name, callable $callback): self
 	{
 		$this->app->resolving($class_name, Closure::fromCallable($callback));
-
+		
 		return $this;
 	}
-
-	protected function getModulesBasePath(): string
+	
+	protected function getModulesBasePath() : string
 	{
 		if (null === $this->modules_path) {
 			$directory_name = $this->app->make('config')->get('app-modules.modules_directory', 'app-modules');
 			$this->modules_path = $this->app->basePath($directory_name);
 		}
-
+		
 		return $this->modules_path;
 	}
-
-	protected function pathToFullyQualifiedClassName($path, ModuleConfig $module_config): string
+	
+	protected function pathToFullyQualifiedClassName($path, ModuleConfig $module_config) : string
 	{
 		foreach ($module_config->namespaces as $namespace_path => $namespace) {
 			if (0 === strpos($path, $namespace_path)) {
 				$relative_path = Str::after($path, $namespace_path);
-				return $namespace . $this->formatPathAsNamespace($relative_path);
+				return $namespace.$this->formatPathAsNamespace($relative_path);
 			}
 		}
-
+		
 		throw new RuntimeException("Unable to infer qualified class name for '{$path}'");
 	}
-
-	protected function formatPathAsNamespace(string $path): string
+	
+	protected function formatPathAsNamespace(string $path) : string
 	{
 		$path = trim($path, DIRECTORY_SEPARATOR);
-
+		
 		$replacements = [
 			'/' => '\\',
 			'.php' => '',
 		];
-
+		
 		return str_replace(
 			array_keys($replacements),
 			array_values($replacements),
 			$path
 		);
 	}
-
-	protected function isInstantiableCommand($command): bool
+	
+	protected function isInstantiableCommand($command) : bool
 	{
 		return is_subclass_of($command, Command::class)
 			&& !(new ReflectionClass($command))->isAbstract();

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -203,8 +203,12 @@ class ModularServiceProvider extends ServiceProvider
 			->livewireComponentFileFinder()
 			->each(function (SplFileInfo $component) {
 			    $module = $this->registry()->moduleForPathOrFail($component->getPath());
-			    $componentName = Str::of($component->getBasename('.php'))->kebab();
-			    \Livewire\Livewire::component($module->name . '::' . $componentName, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+			    $componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
+				return (string)Str::of($item)->kebab();
+			    })->reject(function ($item) {
+				return $item == null;
+			    })->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
+			    \Livewire\Livewire::component($module->name . '::' . $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
 			});
 		}
     	}

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -30,369 +30,369 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class ModularServiceProvider extends ServiceProvider
 {
-    /**
-     * @var \InterNACHI\Modular\Support\ModuleRegistry
-     */
-    protected $registry;
+	/**
+	 * @var \InterNACHI\Modular\Support\ModuleRegistry
+	 */
+	protected $registry;
 
-    /**
-     * @var \InterNACHI\Modular\Support\AutoDiscoveryHelper
-     */
-    protected $auto_discovery_helper;
+	/**
+	 * @var \InterNACHI\Modular\Support\AutoDiscoveryHelper
+	 */
+	protected $auto_discovery_helper;
 
-    /**
-     * This is the base directory of the modular package
-     *
-     * @var string
-     */
-    protected $base_dir;
+	/**
+	 * This is the base directory of the modular package
+	 *
+	 * @var string
+	 */
+	protected $base_dir;
 
-    /**
-     * This is the configured modules directory (app-modules/ by default)
-     * 
-     * @var string 
-     */
-    protected $modules_path;
+	/**
+	 * This is the configured modules directory (app-modules/ by default)
+	 * 
+	 * @var string 
+	 */
+	protected $modules_path;
 
-    public function __construct($app)
-    {
-        parent::__construct($app);
+	public function __construct($app)
+	{
+		parent::__construct($app);
 
-        $this->base_dir = dirname(__DIR__, 2);
-    }
+		$this->base_dir = dirname(__DIR__, 2);
+	}
 
-    public function register(): void
-    {
-        $this->mergeConfigFrom("{$this->base_dir}/config.php", 'app-modules');
+	public function register(): void
+	{
+		$this->mergeConfigFrom("{$this->base_dir}/config.php", 'app-modules');
 
-        $this->app->singleton(ModuleRegistry::class, function () {
-            return new ModuleRegistry(
-                $this->getModulesBasePath(),
-                $this->app->bootstrapPath('cache/modules.php')
-            );
-        });
+		$this->app->singleton(ModuleRegistry::class, function () {
+			return new ModuleRegistry(
+				$this->getModulesBasePath(),
+				$this->app->bootstrapPath('cache/modules.php')
+			);
+		});
 
-        $this->app->singleton(AutoDiscoveryHelper::class, function ($app) {
-            return new AutoDiscoveryHelper(
-                $app->make(ModuleRegistry::class),
-                $app->make(Filesystem::class)
-            );
-        });
+		$this->app->singleton(AutoDiscoveryHelper::class, function ($app) {
+			return new AutoDiscoveryHelper(
+				$app->make(ModuleRegistry::class),
+				$app->make(Filesystem::class)
+			);
+		});
 
-        $this->app->singleton(MakeMigration::class, function ($app) {
-            return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
-        });
+		$this->app->singleton(MakeMigration::class, function ($app) {
+			return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
+		});
 
-        // Set up lazy registrations for things that only need to run if we're using
-        // that functionality (e.g. we only need to look for and register migrations
-        // if we're running the migrator)
-        $this->registerLazily(Migrator::class, [$this, 'registerMigrations']);
-        $this->registerLazily(Gate::class, [$this, 'registerPolicies']);
-        $this->registerLazily(LegacyEloquentFactory::class, [$this, 'registerLegacyFactories']);
+		// Set up lazy registrations for things that only need to run if we're using
+		// that functionality (e.g. we only need to look for and register migrations
+		// if we're running the migrator)
+		$this->registerLazily(Migrator::class, [$this, 'registerMigrations']);
+		$this->registerLazily(Gate::class, [$this, 'registerPolicies']);
+		$this->registerLazily(LegacyEloquentFactory::class, [$this, 'registerLegacyFactories']);
 
-        // If we're running Laravel 8 or higher, set up the Eloquent Factory to resolve
-        // module factories as well as App factories.
-        if (class_exists(EloquentFactory::class)) {
-            $this->registerEloquentFactories();
-        }
+		// If we're running Laravel 8 or higher, set up the Eloquent Factory to resolve
+		// module factories as well as App factories.
+		if (class_exists(EloquentFactory::class)) {
+			$this->registerEloquentFactories();
+		}
 
-        // Look for and register all our commands in the CLI context
-        Artisan::starting(Closure::fromCallable([$this, 'registerCommands']));
-    }
+		// Look for and register all our commands in the CLI context
+		Artisan::starting(Closure::fromCallable([$this, 'registerCommands']));
+	}
 
-    public function boot(): void
-    {
-        $this->publishVendorFiles();
-        $this->bootPackageCommands();
+	public function boot(): void
+	{
+		$this->publishVendorFiles();
+		$this->bootPackageCommands();
 
-        $this->bootRoutes();
-        $this->bootBreadcrumbs();
-        $this->bootViews();
-        $this->bootBladeComponents();
-        $this->bootTranslations();
-        $this->bootLivewireComponents();
-    }
+		$this->bootRoutes();
+		$this->bootBreadcrumbs();
+		$this->bootViews();
+		$this->bootBladeComponents();
+		$this->bootTranslations();
+		$this->bootLivewireComponents();
+	}
 
-    protected function registry(): ModuleRegistry
-    {
-        if (null === $this->registry) {
-            $this->registry = $this->app->make(ModuleRegistry::class);
-        }
+	protected function registry(): ModuleRegistry
+	{
+		if (null === $this->registry) {
+			$this->registry = $this->app->make(ModuleRegistry::class);
+		}
 
-        return $this->registry;
-    }
+		return $this->registry;
+	}
 
-    protected function autoDiscoveryHelper(): AutoDiscoveryHelper
-    {
-        if (null === $this->auto_discovery_helper) {
-            $this->auto_discovery_helper = $this->app->make(AutoDiscoveryHelper::class);
-        }
+	protected function autoDiscoveryHelper(): AutoDiscoveryHelper
+	{
+		if (null === $this->auto_discovery_helper) {
+			$this->auto_discovery_helper = $this->app->make(AutoDiscoveryHelper::class);
+		}
 
-        return $this->auto_discovery_helper;
-    }
+		return $this->auto_discovery_helper;
+	}
 
-    protected function publishVendorFiles(): void
-    {
-        $this->publishes([
-            "{$this->base_dir}/config.php" => $this->app->configPath('app-modules.php'),
-        ], 'modular-config');
-    }
+	protected function publishVendorFiles(): void
+	{
+		$this->publishes([
+			"{$this->base_dir}/config.php" => $this->app->configPath('app-modules.php'),
+		], 'modular-config');
+	}
 
-    protected function bootPackageCommands(): void
-    {
-        if (!$this->app->runningInConsole()) {
-            return;
-        }
+	protected function bootPackageCommands(): void
+	{
+		if (!$this->app->runningInConsole()) {
+			return;
+		}
 
-        $this->commands([
-            MakeModule::class,
-            ModulesCache::class,
-            ModulesClear::class,
-            ModulesSync::class,
-            ModulesList::class,
-        ]);
-    }
+		$this->commands([
+			MakeModule::class,
+			ModulesCache::class,
+			ModulesClear::class,
+			ModulesSync::class,
+			ModulesList::class,
+		]);
+	}
 
-    protected function bootRoutes(): void
-    {
-        if ($this->app->routesAreCached()) {
-            return;
-        }
+	protected function bootRoutes(): void
+	{
+		if ($this->app->routesAreCached()) {
+			return;
+		}
 
-        $this->autoDiscoveryHelper()
-            ->routeFileFinder()
-            ->each(function (SplFileInfo $file) {
-                require $file->getRealPath();
-            });
-    }
+		$this->autoDiscoveryHelper()
+			->routeFileFinder()
+			->each(function (SplFileInfo $file) {
+				require $file->getRealPath();
+			});
+	}
 
-    protected function bootViews(): void
-    {
-        $this->callAfterResolving('view', function (ViewFactory $view_factory) {
-            $this->autoDiscoveryHelper()
-                ->viewDirectoryFinder()
-                ->each(function (SplFileInfo $directory) use ($view_factory) {
-                    $module = $this->registry()->moduleForPathOrFail($directory->getPath());
-                    $view_factory->addNamespace($module->name, $directory->getRealPath());
-                });
-        });
-    }
+	protected function bootViews(): void
+	{
+		$this->callAfterResolving('view', function (ViewFactory $view_factory) {
+			$this->autoDiscoveryHelper()
+				->viewDirectoryFinder()
+				->each(function (SplFileInfo $directory) use ($view_factory) {
+					$module = $this->registry()->moduleForPathOrFail($directory->getPath());
+					$view_factory->addNamespace($module->name, $directory->getRealPath());
+				});
+		});
+	}
 
-    protected function bootBladeComponents(): void
-    {
-        $this->callAfterResolving(BladeCompiler::class, function (BladeCompiler $blade) {
-            $this->autoDiscoveryHelper()
-                ->bladeComponentFileFinder()
-                ->each(function (SplFileInfo $component) use ($blade) {
-                    $module = $this->registry()->moduleForPathOrFail($component->getPath());
-                    $fully_qualified_component = $this->pathToFullyQualifiedClassName($component->getPathname(), $module);
-                    $blade->component($fully_qualified_component, null, $module->name);
-                });
-        });
-    }
+	protected function bootBladeComponents(): void
+	{
+		$this->callAfterResolving(BladeCompiler::class, function (BladeCompiler $blade) {
+			$this->autoDiscoveryHelper()
+				->bladeComponentFileFinder()
+				->each(function (SplFileInfo $component) use ($blade) {
+					$module = $this->registry()->moduleForPathOrFail($component->getPath());
+					$fully_qualified_component = $this->pathToFullyQualifiedClassName($component->getPathname(), $module);
+					$blade->component($fully_qualified_component, null, $module->name);
+				});
+		});
+	}
 
-    protected function bootTranslations(): void
-    {
-        $this->callAfterResolving('translator', function (TranslatorContract $translator) {
-            if (!$translator instanceof Translator) {
-                return;
-            }
+	protected function bootTranslations(): void
+	{
+		$this->callAfterResolving('translator', function (TranslatorContract $translator) {
+			if (!$translator instanceof Translator) {
+				return;
+			}
 
-            $this->autoDiscoveryHelper()
-                ->langDirectoryFinder()
-                ->each(function (SplFileInfo $directory) use ($translator) {
-                    $module = $this->registry()->moduleForPathOrFail($directory->getPath());
-                    $path = $directory->getRealPath();
+			$this->autoDiscoveryHelper()
+				->langDirectoryFinder()
+				->each(function (SplFileInfo $directory) use ($translator) {
+					$module = $this->registry()->moduleForPathOrFail($directory->getPath());
+					$path = $directory->getRealPath();
 
-                    $translator->addNamespace($module->name, $path);
-                    $translator->addJsonPath($path);
-                });
-        });
-    }
+					$translator->addNamespace($module->name, $path);
+					$translator->addJsonPath($path);
+				});
+		});
+	}
 
-    /**
-     * This functionality is likely to go away at some point so don't rely
-     * on it too much. The package has been abandoned.
-     */
-    protected function bootBreadcrumbs(): void
-    {
-        $class_name = 'Diglactic\\Breadcrumbs\\Manager';
+	/**
+	 * This functionality is likely to go away at some point so don't rely
+	 * on it too much. The package has been abandoned.
+	 */
+	protected function bootBreadcrumbs(): void
+	{
+		$class_name = 'Diglactic\\Breadcrumbs\\Manager';
 
-        if (!class_exists($class_name)) {
-            return;
-        }
+		if (!class_exists($class_name)) {
+			return;
+		}
 
-        // The breadcrumbs package makes $breadcrumbs available in the scope of breadcrumb
-        // files, so we'll do the same for consistency-sake
-        $breadcrumbs = $this->app->make($class_name);
+		// The breadcrumbs package makes $breadcrumbs available in the scope of breadcrumb
+		// files, so we'll do the same for consistency-sake
+		$breadcrumbs = $this->app->make($class_name);
 
-        $files = glob($this->getModulesBasePath() . '/*/routes/breadcrumbs/*.php');
+		$files = glob($this->getModulesBasePath() . '/*/routes/breadcrumbs/*.php');
 
-        foreach ($files as $file) {
-            require_once $file;
-        }
-    }
+		foreach ($files as $file) {
+			require_once $file;
+		}
+	}
 
-    protected function bootLivewireComponents(): void
-    {
-        if (class_exists('Livewire\\Livewire')) {
+	protected function bootLivewireComponents(): void
+	{
+		if (class_exists('Livewire\\Livewire')) {
 
-            $this->autoDiscoveryHelper()
-                ->livewireComponentFileFinder()
-                ->each(function (SplFileInfo $component) {
+			$this->autoDiscoveryHelper()
+				->livewireComponentFileFinder()
+				->each(function (SplFileInfo $component) {
 
-                    $module = $this->registry()->moduleForPathOrFail($component->getPath());
+					$module = $this->registry()->moduleForPathOrFail($component->getPath());
 
-                    $componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
-                        return (string)Str::of($item)->kebab();
-                    })->reject(function ($item) {
-                        return $item == null;
-                    })->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
+					$componentPath = collect(explode('/', $component->getRelativePath()))->map(function ($item) {
+						return (string)Str::of($item)->kebab();
+					})->reject(function ($item) {
+						return $item == null;
+					})->push(Str::of($component->getBasename('.php'))->kebab())->implode('.');
 
 
-                    \Livewire\Livewire::component($module->name . '::' . $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
-                });
-        }
-    }
+					\Livewire\Livewire::component($module->name . '::' . $componentPath, $this->pathToFullyQualifiedClassName($component->getPathname(), $module));
+				});
+		}
+	}
 
-    protected function registerMigrations(Migrator $migrator): void
-    {
-        $this->autoDiscoveryHelper()
-            ->migrationDirectoryFinder()
-            ->each(function (SplFileInfo $path) use ($migrator) {
-                $migrator->path($path->getRealPath());
-            });
-    }
+	protected function registerMigrations(Migrator $migrator): void
+	{
+		$this->autoDiscoveryHelper()
+			->migrationDirectoryFinder()
+			->each(function (SplFileInfo $path) use ($migrator) {
+				$migrator->path($path->getRealPath());
+			});
+	}
 
-    protected function registerEloquentFactories(): void
-    {
-        EloquentFactory::guessFactoryNamesUsing(function ($model_name) {
-            // Because Factory::$namespace is protected, we need to access it via reflection.
-            // Hopefully we can PR something into Laravel to make this less hacky.
-            $reflection = new ReflectionProperty(EloquentFactory::class, 'namespace');
-            $reflection->setAccessible(true);
-            $factory_namespace = $reflection->getValue();
+	protected function registerEloquentFactories(): void
+	{
+		EloquentFactory::guessFactoryNamesUsing(function ($model_name) {
+			// Because Factory::$namespace is protected, we need to access it via reflection.
+			// Hopefully we can PR something into Laravel to make this less hacky.
+			$reflection = new ReflectionProperty(EloquentFactory::class, 'namespace');
+			$reflection->setAccessible(true);
+			$factory_namespace = $reflection->getValue();
 
-            $modules_namespace = config('app-modules.modules_namespace', 'Modules');
+			$modules_namespace = config('app-modules.modules_namespace', 'Modules');
 
-            if (
-                Str::startsWith($model_name, $modules_namespace)
-                && $module = $this->registry()->moduleForClass($model_name)
-            ) {
-                $model_name = Str::startsWith($model_name, $module->qualify('Models\\'))
-                    ? Str::after($model_name, $module->qualify('Models\\'))
-                    : Str::after($model_name, $module->namespace());
+			if (
+				Str::startsWith($model_name, $modules_namespace)
+				&& $module = $this->registry()->moduleForClass($model_name)
+			) {
+				$model_name = Str::startsWith($model_name, $module->qualify('Models\\'))
+					? Str::after($model_name, $module->qualify('Models\\'))
+					: Str::after($model_name, $module->namespace());
 
-                return $module->qualify($factory_namespace . $model_name . 'Factory');
-            }
+				return $module->qualify($factory_namespace . $model_name . 'Factory');
+			}
 
-            $model_name = Str::startsWith($model_name, 'App\\Models\\')
-                ? Str::after($model_name, 'App\\Models\\')
-                : Str::after($model_name, 'App\\');
+			$model_name = Str::startsWith($model_name, 'App\\Models\\')
+				? Str::after($model_name, 'App\\Models\\')
+				: Str::after($model_name, 'App\\');
 
-            return $factory_namespace . $model_name . 'Factory';
-        });
-    }
+			return $factory_namespace . $model_name . 'Factory';
+		});
+	}
 
-    protected function registerLegacyFactories(LegacyEloquentFactory $factory): void
-    {
-        $this->autoDiscoveryHelper()
-            ->factoryDirectoryFinder()
-            ->each(function (SplFileInfo $path) use ($factory) {
-                $factory->load($path->getRealPath());
-            });
-    }
+	protected function registerLegacyFactories(LegacyEloquentFactory $factory): void
+	{
+		$this->autoDiscoveryHelper()
+			->factoryDirectoryFinder()
+			->each(function (SplFileInfo $path) use ($factory) {
+				$factory->load($path->getRealPath());
+			});
+	}
 
-    protected function registerPolicies(Gate $gate): void
-    {
-        $this->autoDiscoveryHelper()
-            ->modelFileFinder()
-            ->each(function (SplFileInfo $file) use ($gate) {
-                $module = $this->registry()->moduleForPathOrFail($file->getPath());
-                $fully_qualified_model = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
+	protected function registerPolicies(Gate $gate): void
+	{
+		$this->autoDiscoveryHelper()
+			->modelFileFinder()
+			->each(function (SplFileInfo $file) use ($gate) {
+				$module = $this->registry()->moduleForPathOrFail($file->getPath());
+				$fully_qualified_model = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
 
-                // First, check for a policy that maps to the full namespace of the model
-                // i.e. Models/Foo/Bar -> Policies/Foo/BarPolicy
-                $namespaced_model = Str::after($fully_qualified_model, 'Models\\');
-                $namespaced_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $namespaced_model . 'Policy';
-                if (class_exists($namespaced_policy)) {
-                    $gate->policy($fully_qualified_model, $namespaced_policy);
-                }
+				// First, check for a policy that maps to the full namespace of the model
+				// i.e. Models/Foo/Bar -> Policies/Foo/BarPolicy
+				$namespaced_model = Str::after($fully_qualified_model, 'Models\\');
+				$namespaced_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $namespaced_model . 'Policy';
+				if (class_exists($namespaced_policy)) {
+					$gate->policy($fully_qualified_model, $namespaced_policy);
+				}
 
-                // If that doesn't match, try the simple mapping as well
-                // i.e. Models/Foo/Bar -> Policies/BarPolicy
-                if (false !== strpos($namespaced_model, '\\')) {
-                    $simple_model = Str::afterLast($fully_qualified_model, '\\');
-                    $simple_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $simple_model . 'Policy';
+				// If that doesn't match, try the simple mapping as well
+				// i.e. Models/Foo/Bar -> Policies/BarPolicy
+				if (false !== strpos($namespaced_model, '\\')) {
+					$simple_model = Str::afterLast($fully_qualified_model, '\\');
+					$simple_policy = rtrim($module->namespaces->first(), '\\') . '\\Policies\\' . $simple_model . 'Policy';
 
-                    if (class_exists($simple_policy)) {
-                        $gate->policy($fully_qualified_model, $simple_policy);
-                    }
-                }
-            });
-    }
+					if (class_exists($simple_policy)) {
+						$gate->policy($fully_qualified_model, $simple_policy);
+					}
+				}
+			});
+	}
 
-    protected function registerCommands(Artisan $artisan): void
-    {
-        $this->autoDiscoveryHelper()
-            ->commandFileFinder()
-            ->each(function (SplFileInfo $file) use ($artisan) {
-                $module = $this->registry()->moduleForPathOrFail($file->getPath());
-                $class_name = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
-                if ($this->isInstantiableCommand($class_name)) {
-                    $artisan->resolve($class_name);
-                }
-            });
-    }
+	protected function registerCommands(Artisan $artisan): void
+	{
+		$this->autoDiscoveryHelper()
+			->commandFileFinder()
+			->each(function (SplFileInfo $file) use ($artisan) {
+				$module = $this->registry()->moduleForPathOrFail($file->getPath());
+				$class_name = $this->pathToFullyQualifiedClassName($file->getPathname(), $module);
+				if ($this->isInstantiableCommand($class_name)) {
+					$artisan->resolve($class_name);
+				}
+			});
+	}
 
-    protected function registerLazily(string $class_name, callable $callback): self
-    {
-        $this->app->resolving($class_name, Closure::fromCallable($callback));
+	protected function registerLazily(string $class_name, callable $callback): self
+	{
+		$this->app->resolving($class_name, Closure::fromCallable($callback));
 
-        return $this;
-    }
+		return $this;
+	}
 
-    protected function getModulesBasePath(): string
-    {
-        if (null === $this->modules_path) {
-            $directory_name = $this->app->make('config')->get('app-modules.modules_directory', 'app-modules');
-            $this->modules_path = $this->app->basePath($directory_name);
-        }
+	protected function getModulesBasePath(): string
+	{
+		if (null === $this->modules_path) {
+			$directory_name = $this->app->make('config')->get('app-modules.modules_directory', 'app-modules');
+			$this->modules_path = $this->app->basePath($directory_name);
+		}
 
-        return $this->modules_path;
-    }
+		return $this->modules_path;
+	}
 
-    protected function pathToFullyQualifiedClassName($path, ModuleConfig $module_config): string
-    {
-        foreach ($module_config->namespaces as $namespace_path => $namespace) {
-            if (0 === strpos($path, $namespace_path)) {
-                $relative_path = Str::after($path, $namespace_path);
-                return $namespace . $this->formatPathAsNamespace($relative_path);
-            }
-        }
+	protected function pathToFullyQualifiedClassName($path, ModuleConfig $module_config): string
+	{
+		foreach ($module_config->namespaces as $namespace_path => $namespace) {
+			if (0 === strpos($path, $namespace_path)) {
+				$relative_path = Str::after($path, $namespace_path);
+				return $namespace . $this->formatPathAsNamespace($relative_path);
+			}
+		}
 
-        throw new RuntimeException("Unable to infer qualified class name for '{$path}'");
-    }
+		throw new RuntimeException("Unable to infer qualified class name for '{$path}'");
+	}
 
-    protected function formatPathAsNamespace(string $path): string
-    {
-        $path = trim($path, DIRECTORY_SEPARATOR);
+	protected function formatPathAsNamespace(string $path): string
+	{
+		$path = trim($path, DIRECTORY_SEPARATOR);
 
-        $replacements = [
-            '/' => '\\',
-            '.php' => '',
-        ];
+		$replacements = [
+			'/' => '\\',
+			'.php' => '',
+		];
 
-        return str_replace(
-            array_keys($replacements),
-            array_values($replacements),
-            $path
-        );
-    }
+		return str_replace(
+			array_keys($replacements),
+			array_values($replacements),
+			$path
+		);
+	}
 
-    protected function isInstantiableCommand($command): bool
-    {
-        return is_subclass_of($command, Command::class)
-            && !(new ReflectionClass($command))->isAbstract();
-    }
+	protected function isInstantiableCommand($command): bool
+	{
+		return is_subclass_of($command, Command::class)
+			&& !(new ReflectionClass($command))->isAbstract();
+	}
 }

--- a/src/Support/ModularizedCommandsServiceProvider.php
+++ b/src/Support/ModularizedCommandsServiceProvider.php
@@ -27,45 +27,44 @@ use InterNACHI\Modular\Console\Commands\Make\MakeResource;
 use InterNACHI\Modular\Console\Commands\Make\MakeRule;
 use InterNACHI\Modular\Console\Commands\Make\MakeSeeder;
 use InterNACHI\Modular\Console\Commands\Make\MakeTest;
-use Livewire\Commands\MakeLivewireCommand;
 
 class ModularizedCommandsServiceProvider extends ServiceProvider
 {
-    protected $overrides = [
-        'command.livewire.make' => MakeLivewire::class,
-        'command.controller.make' => MakeController::class,
-        'command.console.make' => MakeCommand::class,
-        'command.channel.make' => MakeChannel::class,
-        'command.event.make' => MakeEvent::class,
-        'command.exception.make' => MakeException::class,
-        'command.factory.make' => MakeFactory::class,
-        'command.job.make' => MakeJob::class,
-        'command.listener.make' => MakeListener::class,
-        'command.mail.make' => MakeMail::class,
-        'command.middleware.make' => MakeMiddleware::class,
-        'command.model.make' => MakeModel::class,
-        'command.notification.make' => MakeNotification::class,
-        'command.observer.make' => MakeObserver::class,
-        'command.policy.make' => MakePolicy::class,
-        'command.provider.make' => MakeProvider::class,
-        'command.request.make' => MakeRequest::class,
-        'command.resource.make' => MakeResource::class,
-        'command.rule.make' => MakeRule::class,
-        'command.seeder.make' => MakeSeeder::class,
-        'command.test.make' => MakeTest::class,
-        'command.component.make' => MakeComponent::class
-    ];
+	protected $overrides = [
+		'command.livewire.make' => MakeLivewire::class,
+		'command.controller.make' => MakeController::class,
+		'command.console.make' => MakeCommand::class,
+		'command.channel.make' => MakeChannel::class,
+		'command.event.make' => MakeEvent::class,
+		'command.exception.make' => MakeException::class,
+		'command.factory.make' => MakeFactory::class,
+		'command.job.make' => MakeJob::class,
+		'command.listener.make' => MakeListener::class,
+		'command.mail.make' => MakeMail::class,
+		'command.middleware.make' => MakeMiddleware::class,
+		'command.model.make' => MakeModel::class,
+		'command.notification.make' => MakeNotification::class,
+		'command.observer.make' => MakeObserver::class,
+		'command.policy.make' => MakePolicy::class,
+		'command.provider.make' => MakeProvider::class,
+		'command.request.make' => MakeRequest::class,
+		'command.resource.make' => MakeResource::class,
+		'command.rule.make' => MakeRule::class,
+		'command.seeder.make' => MakeSeeder::class,
+		'command.test.make' => MakeTest::class,
+		'command.component.make' => MakeComponent::class,
+	];
 
-    public function register(): void
-    {
-        Artisan::starting(function () {
-            foreach ($this->overrides as $alias => $class_name) {
-                $this->app->singleton($alias, $class_name);
-            }
+	public function register(): void
+	{
+		Artisan::starting(function() {
+			foreach ($this->overrides as $alias => $class_name) {
+				$this->app->singleton($alias, $class_name);
+			}
 
-            $this->app->singleton('command.migrate.make', function ($app) {
-                return new MakeMigration($app['migration.creator'], $app['composer']);
-            });
-        });
-    }
+			$this->app->singleton('command.migrate.make', function($app) {
+				return new MakeMigration($app['migration.creator'], $app['composer']);
+			});
+		});
+	}
 }

--- a/src/Support/ModularizedCommandsServiceProvider.php
+++ b/src/Support/ModularizedCommandsServiceProvider.php
@@ -13,6 +13,7 @@ use InterNACHI\Modular\Console\Commands\Make\MakeException;
 use InterNACHI\Modular\Console\Commands\Make\MakeFactory;
 use InterNACHI\Modular\Console\Commands\Make\MakeJob;
 use InterNACHI\Modular\Console\Commands\Make\MakeListener;
+use InterNACHI\Modular\Console\Commands\Make\MakeLivewire;
 use InterNACHI\Modular\Console\Commands\Make\MakeMail;
 use InterNACHI\Modular\Console\Commands\Make\MakeMiddleware;
 use InterNACHI\Modular\Console\Commands\Make\MakeMigration;
@@ -26,43 +27,45 @@ use InterNACHI\Modular\Console\Commands\Make\MakeResource;
 use InterNACHI\Modular\Console\Commands\Make\MakeRule;
 use InterNACHI\Modular\Console\Commands\Make\MakeSeeder;
 use InterNACHI\Modular\Console\Commands\Make\MakeTest;
+use Livewire\Commands\MakeLivewireCommand;
 
 class ModularizedCommandsServiceProvider extends ServiceProvider
 {
-	protected $overrides = [
-		'command.controller.make' => MakeController::class,
-		'command.console.make' => MakeCommand::class,
-		'command.channel.make' => MakeChannel::class,
-		'command.event.make' => MakeEvent::class,
-		'command.exception.make' => MakeException::class,
-		'command.factory.make' => MakeFactory::class,
-		'command.job.make' => MakeJob::class,
-		'command.listener.make' => MakeListener::class,
-		'command.mail.make' => MakeMail::class,
-		'command.middleware.make' => MakeMiddleware::class,
-		'command.model.make' => MakeModel::class,
-		'command.notification.make' => MakeNotification::class,
-		'command.observer.make' => MakeObserver::class,
-		'command.policy.make' => MakePolicy::class,
-		'command.provider.make' => MakeProvider::class,
-		'command.request.make' => MakeRequest::class,
-		'command.resource.make' => MakeResource::class,
-		'command.rule.make' => MakeRule::class,
-		'command.seeder.make' => MakeSeeder::class,
-		'command.test.make' => MakeTest::class,
-		'command.component.make' => MakeComponent::class,
-	];
-	
-	public function register(): void
-	{
-		Artisan::starting(function() {
-			foreach ($this->overrides as $alias => $class_name) {
-				$this->app->singleton($alias, $class_name);
-			}
-			
-			$this->app->singleton('command.migrate.make', function($app) {
-				return new MakeMigration($app['migration.creator'], $app['composer']);
-			});
-		});
-	}
+    protected $overrides = [
+        'command.livewire.make' => MakeLivewire::class,
+        'command.controller.make' => MakeController::class,
+        'command.console.make' => MakeCommand::class,
+        'command.channel.make' => MakeChannel::class,
+        'command.event.make' => MakeEvent::class,
+        'command.exception.make' => MakeException::class,
+        'command.factory.make' => MakeFactory::class,
+        'command.job.make' => MakeJob::class,
+        'command.listener.make' => MakeListener::class,
+        'command.mail.make' => MakeMail::class,
+        'command.middleware.make' => MakeMiddleware::class,
+        'command.model.make' => MakeModel::class,
+        'command.notification.make' => MakeNotification::class,
+        'command.observer.make' => MakeObserver::class,
+        'command.policy.make' => MakePolicy::class,
+        'command.provider.make' => MakeProvider::class,
+        'command.request.make' => MakeRequest::class,
+        'command.resource.make' => MakeResource::class,
+        'command.rule.make' => MakeRule::class,
+        'command.seeder.make' => MakeSeeder::class,
+        'command.test.make' => MakeTest::class,
+        'command.component.make' => MakeComponent::class
+    ];
+
+    public function register(): void
+    {
+        Artisan::starting(function () {
+            foreach ($this->overrides as $alias => $class_name) {
+                $this->app->singleton($alias, $class_name);
+            }
+
+            $this->app->singleton('command.migrate.make', function ($app) {
+                return new MakeMigration($app['migration.creator'], $app['composer']);
+            });
+        });
+    }
 }

--- a/src/Support/ModularizedCommandsServiceProvider.php
+++ b/src/Support/ModularizedCommandsServiceProvider.php
@@ -54,14 +54,14 @@ class ModularizedCommandsServiceProvider extends ServiceProvider
 		'command.test.make' => MakeTest::class,
 		'command.component.make' => MakeComponent::class,
 	];
-
+	
 	public function register(): void
 	{
 		Artisan::starting(function() {
 			foreach ($this->overrides as $alias => $class_name) {
 				$this->app->singleton($alias, $class_name);
 			}
-
+			
 			$this->app->singleton('command.migrate.make', function($app) {
 				return new MakeMigration($app['migration.creator'], $app['composer']);
 			});

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -2,202 +2,200 @@
 
 namespace InterNACHI\Modular\Tests;
 
-use Livewire\Livewire;
 use Illuminate\Filesystem\Filesystem;
+use InterNACHI\Modular\Console\Commands\Make\MakeCommand;
+use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
+use InterNACHI\Modular\Console\Commands\Make\MakeLivewire;
+use InterNACHI\Modular\Console\Commands\Make\MakeModel;
+use InterNACHI\Modular\Support\AutoDiscoveryHelper;
+use InterNACHI\Modular\Support\ModuleRegistry;
+use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
 use Livewire\LivewireServiceProvider;
 use Symfony\Component\Finder\SplFileInfo;
-use InterNACHI\Modular\Support\ModuleRegistry;
-use InterNACHI\Modular\Support\AutoDiscoveryHelper;
-use InterNACHI\Modular\Console\Commands\Make\MakeModel;
-use InterNACHI\Modular\Console\Commands\Make\MakeCommand;
-use InterNACHI\Modular\Console\Commands\Make\MakeLivewire;
-use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
-use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
 
 class AutoDiscoveryHelperTest extends TestCase
 {
-    use WritesToAppFilesystem;
+	use WritesToAppFilesystem;
 
-    protected $module1;
+	protected $module1;
 
-    protected $module2;
+	protected $module2;
 
-    protected $helper;
+	protected $helper;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+	protected function setUp(): void
+	{
+		parent::setUp();
 
-        $this->module1 = $this->makeModule('test-module');
-        $this->module2 = $this->makeModule('test-module-two');
-        $this->helper = new AutoDiscoveryHelper(
-            new ModuleRegistry($this->getBasePath() . '/app-modules', ''),
-            new Filesystem()
-        );
-    }
+		$this->module1 = $this->makeModule('test-module');
+		$this->module2 = $this->makeModule('test-module-two');
+		$this->helper = new AutoDiscoveryHelper(
+			new ModuleRegistry($this->getBasePath().'/app-modules', ''),
+			new Filesystem()
+		);
+	}
 
-    public function test_it_finds_commands(): void
-    {
-        $this->artisan(MakeCommand::class, [
-            'name' => 'TestCommand',
-            '--module' => $this->module1->name,
-        ]);
+	public function test_it_finds_commands(): void
+	{
+		$this->artisan(MakeCommand::class, [
+			'name' => 'TestCommand',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeCommand::class, [
-            'name' => 'TestCommand',
-            '--module' => $this->module2->name,
-        ]);
+		$this->artisan(MakeCommand::class, [
+			'name' => 'TestCommand',
+			'--module' => $this->module2->name,
+		]);
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->commandFileFinder()->each(function (SplFileInfo $command) use (&$resolved) {
-            $resolved[] = $command->getPathname();
-        });
+		$this->helper->commandFileFinder()->each(function(SplFileInfo $command) use (&$resolved) {
+			$resolved[] = $command->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
-        $this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
+		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
+	}
 
-    public function test_it_finds_factory_directories(): void
-    {
-        $resolved = [];
+	public function test_it_finds_factory_directories(): void
+	{
+		$resolved = [];
 
-        $this->helper->factoryDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->factoryDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('database/factories'), $resolved);
-        $this->assertContains($this->module2->path('database/factories'), $resolved);
-    }
+		$this->assertContains($this->module1->path('database/factories'), $resolved);
+		$this->assertContains($this->module2->path('database/factories'), $resolved);
+	}
 
-    public function test_it_finds_migration_directories(): void
-    {
-        $resolved = [];
+	public function test_it_finds_migration_directories(): void
+	{
+		$resolved = [];
 
-        $this->helper->migrationDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->migrationDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('database/migrations'), $resolved);
-        $this->assertContains($this->module2->path('database/migrations'), $resolved);
-    }
+		$this->assertContains($this->module1->path('database/migrations'), $resolved);
+		$this->assertContains($this->module2->path('database/migrations'), $resolved);
+	}
 
-    public function test_it_finds_models(): void
-    {
-        $this->artisan(MakeModel::class, [
-            'name' => 'TestModel',
-            '--module' => $this->module1->name,
-        ]);
+	public function test_it_finds_models(): void
+	{
+		$this->artisan(MakeModel::class, [
+			'name' => 'TestModel',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeModel::class, [
-            'name' => 'TestModel',
-            '--module' => $this->module2->name,
-        ]);
+		$this->artisan(MakeModel::class, [
+			'name' => 'TestModel',
+			'--module' => $this->module2->name,
+		]);
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->modelFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->helper->modelFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
-        $this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
+		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
+	}
 
-    public function test_it_finds_blade_components(): void
-    {
-        $this->artisan(MakeComponent::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module1->name,
-        ]);
+	public function test_it_finds_blade_components(): void
+	{
+		$this->artisan(MakeComponent::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeComponent::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module2->name,
-        ]);
+		$this->artisan(MakeComponent::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module2->name,
+		]);
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->bladeComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
-        $this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
+		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
+	}
 
-    public function test_it_finds_routes(): void
-    {
-        $resolved = [];
+	public function test_it_finds_routes(): void
+	{
+		$resolved = [];
 
-        $this->helper->routeFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->helper->routeFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
-        $this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
-    }
+		$this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
+		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
+	}
 
-    public function test_it_finds_view_directories(): void
-    {
-        $resolved = [];
+	public function test_it_finds_view_directories(): void
+	{
+		$resolved = [];
 
-        $this->helper->viewDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->viewDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('resources/views'), $resolved);
-        $this->assertContains($this->module2->path('resources/views'), $resolved);
-    }
+		$this->assertContains($this->module1->path('resources/views'), $resolved);
+		$this->assertContains($this->module2->path('resources/views'), $resolved);
+	}
 
-    public function test_it_finds_lang_directories(): void
-    {
-        // These paths don't exist by default
-        $fs = new Filesystem();
-        $fs->makeDirectory($this->module1->path('resources/lang'));
-        $fs->makeDirectory($this->module2->path('resources/lang'));
+	public function test_it_finds_lang_directories(): void
+	{
+		// These paths don't exist by default
+		$fs = new Filesystem();
+		$fs->makeDirectory($this->module1->path('resources/lang'));
+		$fs->makeDirectory($this->module2->path('resources/lang'));
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->langDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->langDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('resources/lang'), $resolved);
-        $this->assertContains($this->module2->path('resources/lang'), $resolved);
-    }
+		$this->assertContains($this->module1->path('resources/lang'), $resolved);
+		$this->assertContains($this->module2->path('resources/lang'), $resolved);
+	}
 
-    public function test_it_finds_livewire_component(): void
-    {
+	public function test_it_finds_livewire_component(): void
+	{
+		$this->artisan(MakeLivewire::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeLivewire::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module1->name,
-        ]);
+		$this->artisan(MakeLivewire::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module2->name,
+		]);
 
-        $this->artisan(MakeLivewire::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module2->name,
-        ]);
+		$resolved = [];
 
-        $resolved = [];
+		$this->helper->livewireComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->helper->livewireComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->assertContains($this->module1->path('src/Http/Livewire/TestComponent.php'), $resolved);
+		$this->assertContains($this->module2->path('src/Http/Livewire/TestComponent.php'), $resolved);
+	}
 
-        $this->assertContains($this->module1->path('src/Http/Livewire/TestComponent.php'), $resolved);
-        $this->assertContains($this->module2->path('src/Http/Livewire/TestComponent.php'), $resolved);
-    }
+	protected function getPackageProviders($app)
+	{
+		$providers = parent::getPackageProviders($app);
 
-    protected function getPackageProviders($app)
-    {
-        $providers = parent::getPackageProviders($app);
+		if (class_exists(LivewireServiceProvider::class)) {
+			$providers[] = LivewireServiceProvider::class;
+		}
 
-        if (class_exists(LivewireServiceProvider::class)) {
-            $providers[] = LivewireServiceProvider::class;
-        }
-
-        return $providers;
-    }
+		return $providers;
+	}
 }

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -2,187 +2,202 @@
 
 namespace InterNACHI\Modular\Tests;
 
+use Livewire\Livewire;
 use Illuminate\Filesystem\Filesystem;
-use InterNACHI\Modular\Console\Commands\Make\MakeCommand;
-use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
-use InterNACHI\Modular\Console\Commands\Make\MakeModel;
-use InterNACHI\Modular\Support\AutoDiscoveryHelper;
-use InterNACHI\Modular\Support\ModuleRegistry;
-use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
+use Livewire\LivewireServiceProvider;
 use Symfony\Component\Finder\SplFileInfo;
+use InterNACHI\Modular\Support\ModuleRegistry;
+use InterNACHI\Modular\Support\AutoDiscoveryHelper;
+use InterNACHI\Modular\Console\Commands\Make\MakeModel;
+use InterNACHI\Modular\Console\Commands\Make\MakeCommand;
+use InterNACHI\Modular\Console\Commands\Make\MakeLivewire;
+use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
+use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
 
 class AutoDiscoveryHelperTest extends TestCase
 {
-	use WritesToAppFilesystem;
-	
-	protected $module1;
-	
-	protected $module2;
-	
-	protected $helper;
-	
-	protected function setUp(): void
-	{
-		parent::setUp();
-		
-		$this->module1 = $this->makeModule('test-module');
-		$this->module2 = $this->makeModule('test-module-two');
-		$this->helper = new AutoDiscoveryHelper(
-			new ModuleRegistry($this->getBasePath().'/app-modules', ''),
-			new Filesystem()
-		);
-	}
-	
-	public function test_it_finds_commands(): void
-	{
-		$this->artisan(MakeCommand::class, [
-			'name' => 'TestCommand',
-			'--module' => $this->module1->name,
-		]);
-		
-		$this->artisan(MakeCommand::class, [
-			'name' => 'TestCommand',
-			'--module' => $this->module2->name,
-		]);
-		
-		$resolved = [];
-		
-		$this->helper->commandFileFinder()->each(function(SplFileInfo $command) use (&$resolved) {
-			$resolved[] = $command->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
-		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
-	}
-	
-	public function test_it_finds_factory_directories(): void
-	{
-		$resolved = [];
-		
-		$this->helper->factoryDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('database/factories'), $resolved);
-		$this->assertContains($this->module2->path('database/factories'), $resolved);
-	}
-	
-	public function test_it_finds_migration_directories(): void
-	{
-		$resolved = [];
-		
-		$this->helper->migrationDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('database/migrations'), $resolved);
-		$this->assertContains($this->module2->path('database/migrations'), $resolved);
-	}
-	
-	public function test_it_finds_models(): void
-	{
-		$this->artisan(MakeModel::class, [
-			'name' => 'TestModel',
-			'--module' => $this->module1->name,
-		]);
-		
-		$this->artisan(MakeModel::class, [
-			'name' => 'TestModel',
-			'--module' => $this->module2->name,
-		]);
-		
-		$resolved = [];
-		
-		$this->helper->modelFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
-		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
-	}
-	
-	public function test_it_finds_blade_components(): void
-	{
-		$this->artisan(MakeComponent::class, [
-			'name' => 'TestComponent',
-			'--module' => $this->module1->name,
-		]);
-		
-		$this->artisan(MakeComponent::class, [
-			'name' => 'TestComponent',
-			'--module' => $this->module2->name,
-		]);
-		
-		$resolved = [];
-		
-		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
-		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
-	}
-	
-	public function test_it_finds_routes(): void
-	{
-		$resolved = [];
-		
-		$this->helper->routeFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
-		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
-	}
-	
-	public function test_it_finds_view_directories(): void
-	{
-		$resolved = [];
-		
-		$this->helper->viewDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('resources/views'), $resolved);
-		$this->assertContains($this->module2->path('resources/views'), $resolved);
-	}
-	
-	public function test_it_finds_lang_directories(): void
-	{
-		// These paths don't exist by default
-		$fs = new Filesystem();
-		$fs->makeDirectory($this->module1->path('resources/lang'));
-		$fs->makeDirectory($this->module2->path('resources/lang'));
-		
-		$resolved = [];
-		
-		$this->helper->langDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('resources/lang'), $resolved);
-		$this->assertContains($this->module2->path('resources/lang'), $resolved);
-	}
+    use WritesToAppFilesystem;
 
-	public function test_it_finds_livewire_component(): void
-	{
-		$this->artisan(MakeComponent::class, [
-			'name' => 'TestComponent',
-			'--module' => $this->module1->name,
-		]);
+    protected $module1;
 
-		$this->artisan(MakeComponent::class, [
-			'name' => 'TestComponent',
-			'--module' => $this->module2->name,
-		]);
+    protected $module2;
 
-		$resolved = [];
+    protected $helper;
 
-		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
+    protected function setUp(): void
+    {
+        parent::setUp();
 
-		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
-		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
-	}
+        $this->module1 = $this->makeModule('test-module');
+        $this->module2 = $this->makeModule('test-module-two');
+        $this->helper = new AutoDiscoveryHelper(
+            new ModuleRegistry($this->getBasePath() . '/app-modules', ''),
+            new Filesystem()
+        );
+    }
+
+    public function test_it_finds_commands(): void
+    {
+        $this->artisan(MakeCommand::class, [
+            'name' => 'TestCommand',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeCommand::class, [
+            'name' => 'TestCommand',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->commandFileFinder()->each(function (SplFileInfo $command) use (&$resolved) {
+            $resolved[] = $command->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
+        $this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
+    }
+
+    public function test_it_finds_factory_directories(): void
+    {
+        $resolved = [];
+
+        $this->helper->factoryDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('database/factories'), $resolved);
+        $this->assertContains($this->module2->path('database/factories'), $resolved);
+    }
+
+    public function test_it_finds_migration_directories(): void
+    {
+        $resolved = [];
+
+        $this->helper->migrationDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('database/migrations'), $resolved);
+        $this->assertContains($this->module2->path('database/migrations'), $resolved);
+    }
+
+    public function test_it_finds_models(): void
+    {
+        $this->artisan(MakeModel::class, [
+            'name' => 'TestModel',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeModel::class, [
+            'name' => 'TestModel',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->modelFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
+        $this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
+    }
+
+    public function test_it_finds_blade_components(): void
+    {
+        $this->artisan(MakeComponent::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeComponent::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->bladeComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
+        $this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
+    }
+
+    public function test_it_finds_routes(): void
+    {
+        $resolved = [];
+
+        $this->helper->routeFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
+        $this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
+    }
+
+    public function test_it_finds_view_directories(): void
+    {
+        $resolved = [];
+
+        $this->helper->viewDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('resources/views'), $resolved);
+        $this->assertContains($this->module2->path('resources/views'), $resolved);
+    }
+
+    public function test_it_finds_lang_directories(): void
+    {
+        // These paths don't exist by default
+        $fs = new Filesystem();
+        $fs->makeDirectory($this->module1->path('resources/lang'));
+        $fs->makeDirectory($this->module2->path('resources/lang'));
+
+        $resolved = [];
+
+        $this->helper->langDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('resources/lang'), $resolved);
+        $this->assertContains($this->module2->path('resources/lang'), $resolved);
+    }
+
+    public function test_it_finds_livewire_component(): void
+    {
+
+        $this->artisan(MakeLivewire::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeLivewire::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->livewireComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/Http/Livewire/TestComponent.php'), $resolved);
+        $this->assertContains($this->module2->path('src/Http/Livewire/TestComponent.php'), $resolved);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        $providers = parent::getPackageProviders($app);
+
+        if (class_exists(LivewireServiceProvider::class)) {
+            $providers[] = LivewireServiceProvider::class;
+        }
+
+        return $providers;
+    }
 }

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -13,177 +13,176 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class AutoDiscoveryHelperTest extends TestCase
 {
-    use WritesToAppFilesystem;
+	use WritesToAppFilesystem;
 
-    protected $module1;
+	protected $module1;
 
-    protected $module2;
+	protected $module2;
 
-    protected $helper;
+	protected $helper;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+	protected function setUp(): void
+	{
+		parent::setUp();
 
-        $this->module1 = $this->makeModule('test-module');
-        $this->module2 = $this->makeModule('test-module-two');
-        $this->helper = new AutoDiscoveryHelper(
-            new ModuleRegistry($this->getBasePath() . '/app-modules', ''),
-            new Filesystem()
-        );
-    }
+		$this->module1 = $this->makeModule('test-module');
+		$this->module2 = $this->makeModule('test-module-two');
+		$this->helper = new AutoDiscoveryHelper(
+			new ModuleRegistry($this->getBasePath().'/app-modules', ''),
+			new Filesystem()
+		);
+	}
 
-    public function test_it_finds_commands(): void
-    {
-        $this->artisan(MakeCommand::class, [
-            'name' => 'TestCommand',
-            '--module' => $this->module1->name,
-        ]);
+	public function test_it_finds_commands(): void
+	{
+		$this->artisan(MakeCommand::class, [
+			'name' => 'TestCommand',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeCommand::class, [
-            'name' => 'TestCommand',
-            '--module' => $this->module2->name,
-        ]);
+		$this->artisan(MakeCommand::class, [
+			'name' => 'TestCommand',
+			'--module' => $this->module2->name,
+		]);
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->commandFileFinder()->each(function (SplFileInfo $command) use (&$resolved) {
-            $resolved[] = $command->getPathname();
-        });
+		$this->helper->commandFileFinder()->each(function(SplFileInfo $command) use (&$resolved) {
+			$resolved[] = $command->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
-        $this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
+		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
+	}
 
-    public function test_it_finds_factory_directories(): void
-    {
-        $resolved = [];
+	public function test_it_finds_factory_directories(): void
+	{
+		$resolved = [];
 
-        $this->helper->factoryDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->factoryDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('database/factories'), $resolved);
-        $this->assertContains($this->module2->path('database/factories'), $resolved);
-    }
+		$this->assertContains($this->module1->path('database/factories'), $resolved);
+		$this->assertContains($this->module2->path('database/factories'), $resolved);
+	}
 
-    public function test_it_finds_migration_directories(): void
-    {
-        $resolved = [];
+	public function test_it_finds_migration_directories(): void
+	{
+		$resolved = [];
 
-        $this->helper->migrationDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->migrationDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('database/migrations'), $resolved);
-        $this->assertContains($this->module2->path('database/migrations'), $resolved);
-    }
+		$this->assertContains($this->module1->path('database/migrations'), $resolved);
+		$this->assertContains($this->module2->path('database/migrations'), $resolved);
+	}
 
-    public function test_it_finds_models(): void
-    {
-        $this->artisan(MakeModel::class, [
-            'name' => 'TestModel',
-            '--module' => $this->module1->name,
-        ]);
+	public function test_it_finds_models(): void
+	{
+		$this->artisan(MakeModel::class, [
+			'name' => 'TestModel',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeModel::class, [
-            'name' => 'TestModel',
-            '--module' => $this->module2->name,
-        ]);
+		$this->artisan(MakeModel::class, [
+			'name' => 'TestModel',
+			'--module' => $this->module2->name,
+		]);
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->modelFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->helper->modelFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
-        $this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
+		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
+	}
 
-    public function test_it_finds_blade_components(): void
-    {
-        $this->artisan(MakeComponent::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module1->name,
-        ]);
+	public function test_it_finds_blade_components(): void
+	{
+		$this->artisan(MakeComponent::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeComponent::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module2->name,
-        ]);
+		$this->artisan(MakeComponent::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module2->name,
+		]);
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->bladeComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
-        $this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
+		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
+	}
 
-    public function test_it_finds_routes(): void
-    {
-        $resolved = [];
+	public function test_it_finds_routes(): void
+	{
+		$resolved = [];
 
-        $this->helper->routeFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
+		$this->helper->routeFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
-        $this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
-    }
+		$this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
+		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
+	}
 
-    public function test_it_finds_view_directories(): void
-    {
-        $resolved = [];
+	public function test_it_finds_view_directories(): void
+	{
+		$resolved = [];
 
-        $this->helper->viewDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->viewDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('resources/views'), $resolved);
-        $this->assertContains($this->module2->path('resources/views'), $resolved);
-    }
+		$this->assertContains($this->module1->path('resources/views'), $resolved);
+		$this->assertContains($this->module2->path('resources/views'), $resolved);
+	}
 
-    public function test_it_finds_lang_directories(): void
-    {
-        // These paths don't exist by default
-        $fs = new Filesystem();
-        $fs->makeDirectory($this->module1->path('resources/lang'));
-        $fs->makeDirectory($this->module2->path('resources/lang'));
+	public function test_it_finds_lang_directories(): void
+	{
+		// These paths don't exist by default
+		$fs = new Filesystem();
+		$fs->makeDirectory($this->module1->path('resources/lang'));
+		$fs->makeDirectory($this->module2->path('resources/lang'));
 
-        $resolved = [];
+		$resolved = [];
 
-        $this->helper->langDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
-            $resolved[] = $directory->getPathname();
-        });
+		$this->helper->langDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
+			$resolved[] = $directory->getPathname();
+		});
 
-        $this->assertContains($this->module1->path('resources/lang'), $resolved);
-        $this->assertContains($this->module2->path('resources/lang'), $resolved);
-    }
+		$this->assertContains($this->module1->path('resources/lang'), $resolved);
+		$this->assertContains($this->module2->path('resources/lang'), $resolved);
+	}
 
-    public function test_it_finds_livewire_component(): void
-    {
+	public function test_it_finds_livewire_component(): void
+	{
+		$this->artisan(MakeComponent::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module1->name,
+		]);
 
-        $this->artisan(MakeComponent::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module1->name,
-        ]);
+		$this->artisan(MakeComponent::class, [
+			'name' => 'TestComponent',
+			'--module' => $this->module2->name,
+		]);
 
-        $this->artisan(MakeComponent::class, [
-            'name' => 'TestComponent',
-            '--module' => $this->module2->name,
-        ]);
+		$resolved = [];
 
-        $resolved = [];
+		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
+			$resolved[] = $file->getPathname();
+		});
 
-        $this->helper->bladeComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
-            $resolved[] = $file->getPathname();
-        });
-
-        $this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
-        $this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
-    }
+		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
+		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
+	}
 }

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -23,7 +23,7 @@ class AutoDiscoveryHelperTest extends TestCase
 	
 	protected $helper;
 	
-	protected function setUp() : void
+	protected function setUp(): void
 	{
 		parent::setUp();
 		
@@ -35,7 +35,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		);
 	}
 	
-	public function test_it_finds_commands() : void
+	public function test_it_finds_commands(): void
 	{
 		$this->artisan(MakeCommand::class, [
 			'name' => 'TestCommand',
@@ -57,7 +57,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
 	}
 	
-	public function test_it_finds_factory_directories() : void
+	public function test_it_finds_factory_directories(): void
 	{
 		$resolved = [];
 		
@@ -69,7 +69,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('database/factories'), $resolved);
 	}
 	
-	public function test_it_finds_migration_directories() : void
+	public function test_it_finds_migration_directories(): void
 	{
 		$resolved = [];
 		
@@ -81,7 +81,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('database/migrations'), $resolved);
 	}
 	
-	public function test_it_finds_models() : void
+	public function test_it_finds_models(): void
 	{
 		$this->artisan(MakeModel::class, [
 			'name' => 'TestModel',
@@ -103,7 +103,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
 	}
 	
-	public function test_it_finds_blade_components() : void
+	public function test_it_finds_blade_components(): void
 	{
 		$this->artisan(MakeComponent::class, [
 			'name' => 'TestComponent',
@@ -125,7 +125,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
 	}
 	
-	public function test_it_finds_routes() : void
+	public function test_it_finds_routes(): void
 	{
 		$resolved = [];
 		
@@ -137,7 +137,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
 	}
 	
-	public function test_it_finds_view_directories() : void
+	public function test_it_finds_view_directories(): void
 	{
 		$resolved = [];
 		
@@ -149,7 +149,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('resources/views'), $resolved);
 	}
 	
-	public function test_it_finds_lang_directories() : void
+	public function test_it_finds_lang_directories(): void
 	{
 		// These paths don't exist by default
 		$fs = new Filesystem();
@@ -166,7 +166,7 @@ class AutoDiscoveryHelperTest extends TestCase
 		$this->assertContains($this->module2->path('resources/lang'), $resolved);
 	}
 	
-	public function test_it_finds_livewire_component() : void
+	public function test_it_finds_livewire_component(): void
 	{
 		$this->artisan(MakeLivewire::class, [
 			'name' => 'TestComponent',

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -16,17 +16,17 @@ use Symfony\Component\Finder\SplFileInfo;
 class AutoDiscoveryHelperTest extends TestCase
 {
 	use WritesToAppFilesystem;
-
+	
 	protected $module1;
-
+	
 	protected $module2;
-
+	
 	protected $helper;
-
-	protected function setUp(): void
+	
+	protected function setUp() : void
 	{
 		parent::setUp();
-
+		
 		$this->module1 = $this->makeModule('test-module');
 		$this->module2 = $this->makeModule('test-module-two');
 		$this->helper = new AutoDiscoveryHelper(
@@ -34,168 +34,168 @@ class AutoDiscoveryHelperTest extends TestCase
 			new Filesystem()
 		);
 	}
-
-	public function test_it_finds_commands(): void
+	
+	public function test_it_finds_commands() : void
 	{
 		$this->artisan(MakeCommand::class, [
 			'name' => 'TestCommand',
 			'--module' => $this->module1->name,
 		]);
-
+		
 		$this->artisan(MakeCommand::class, [
 			'name' => 'TestCommand',
 			'--module' => $this->module2->name,
 		]);
-
+		
 		$resolved = [];
-
+		
 		$this->helper->commandFileFinder()->each(function(SplFileInfo $command) use (&$resolved) {
 			$resolved[] = $command->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
 		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
 	}
-
-	public function test_it_finds_factory_directories(): void
+	
+	public function test_it_finds_factory_directories() : void
 	{
 		$resolved = [];
-
+		
 		$this->helper->factoryDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
 			$resolved[] = $directory->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('database/factories'), $resolved);
 		$this->assertContains($this->module2->path('database/factories'), $resolved);
 	}
-
-	public function test_it_finds_migration_directories(): void
+	
+	public function test_it_finds_migration_directories() : void
 	{
 		$resolved = [];
-
+		
 		$this->helper->migrationDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
 			$resolved[] = $directory->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('database/migrations'), $resolved);
 		$this->assertContains($this->module2->path('database/migrations'), $resolved);
 	}
-
-	public function test_it_finds_models(): void
+	
+	public function test_it_finds_models() : void
 	{
 		$this->artisan(MakeModel::class, [
 			'name' => 'TestModel',
 			'--module' => $this->module1->name,
 		]);
-
+		
 		$this->artisan(MakeModel::class, [
 			'name' => 'TestModel',
 			'--module' => $this->module2->name,
 		]);
-
+		
 		$resolved = [];
-
+		
 		$this->helper->modelFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
 			$resolved[] = $file->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
 		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
 	}
-
-	public function test_it_finds_blade_components(): void
+	
+	public function test_it_finds_blade_components() : void
 	{
 		$this->artisan(MakeComponent::class, [
 			'name' => 'TestComponent',
 			'--module' => $this->module1->name,
 		]);
-
+		
 		$this->artisan(MakeComponent::class, [
 			'name' => 'TestComponent',
 			'--module' => $this->module2->name,
 		]);
-
+		
 		$resolved = [];
-
+		
 		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
 			$resolved[] = $file->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
 		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
 	}
-
-	public function test_it_finds_routes(): void
+	
+	public function test_it_finds_routes() : void
 	{
 		$resolved = [];
-
+		
 		$this->helper->routeFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
 			$resolved[] = $file->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
 		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
 	}
-
-	public function test_it_finds_view_directories(): void
+	
+	public function test_it_finds_view_directories() : void
 	{
 		$resolved = [];
-
+		
 		$this->helper->viewDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
 			$resolved[] = $directory->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('resources/views'), $resolved);
 		$this->assertContains($this->module2->path('resources/views'), $resolved);
 	}
-
-	public function test_it_finds_lang_directories(): void
+	
+	public function test_it_finds_lang_directories() : void
 	{
 		// These paths don't exist by default
 		$fs = new Filesystem();
 		$fs->makeDirectory($this->module1->path('resources/lang'));
 		$fs->makeDirectory($this->module2->path('resources/lang'));
-
+		
 		$resolved = [];
-
+		
 		$this->helper->langDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
 			$resolved[] = $directory->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('resources/lang'), $resolved);
 		$this->assertContains($this->module2->path('resources/lang'), $resolved);
 	}
-
-	public function test_it_finds_livewire_component(): void
+	
+	public function test_it_finds_livewire_component() : void
 	{
 		$this->artisan(MakeLivewire::class, [
 			'name' => 'TestComponent',
 			'--module' => $this->module1->name,
 		]);
-
+		
 		$this->artisan(MakeLivewire::class, [
 			'name' => 'TestComponent',
 			'--module' => $this->module2->name,
 		]);
-
+		
 		$resolved = [];
-
+		
 		$this->helper->livewireComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
 			$resolved[] = $file->getPathname();
 		});
-
+		
 		$this->assertContains($this->module1->path('src/Http/Livewire/TestComponent.php'), $resolved);
 		$this->assertContains($this->module2->path('src/Http/Livewire/TestComponent.php'), $resolved);
 	}
-
+	
 	protected function getPackageProviders($app)
 	{
 		$providers = parent::getPackageProviders($app);
-
+		
 		if (class_exists(LivewireServiceProvider::class)) {
 			$providers[] = LivewireServiceProvider::class;
 		}
-
+		
 		return $providers;
 	}
 }

--- a/tests/AutoDiscoveryHelperTest.php
+++ b/tests/AutoDiscoveryHelperTest.php
@@ -13,154 +13,177 @@ use Symfony\Component\Finder\SplFileInfo;
 
 class AutoDiscoveryHelperTest extends TestCase
 {
-	use WritesToAppFilesystem;
-	
-	protected $module1;
-	
-	protected $module2;
-	
-	protected $helper;
-	
-	protected function setUp() : void
-	{
-		parent::setUp();
-		
-		$this->module1 = $this->makeModule('test-module');
-		$this->module2 = $this->makeModule('test-module-two');
-		$this->helper = new AutoDiscoveryHelper(
-			new ModuleRegistry($this->getBasePath().'/app-modules', ''),
-			new Filesystem()
-		);
-	}
-	
-	public function test_it_finds_commands() : void
-	{
-		$this->artisan(MakeCommand::class, [
-			'name' => 'TestCommand',
-			'--module' => $this->module1->name,
-		]);
-		
-		$this->artisan(MakeCommand::class, [
-			'name' => 'TestCommand',
-			'--module' => $this->module2->name,
-		]);
-		
-		$resolved = [];
-		
-		$this->helper->commandFileFinder()->each(function(SplFileInfo $command) use (&$resolved) {
-			$resolved[] = $command->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
-		$this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
-	}
-	
-	public function test_it_finds_factory_directories() : void
-	{
-		$resolved = [];
-		
-		$this->helper->factoryDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('database/factories'), $resolved);
-		$this->assertContains($this->module2->path('database/factories'), $resolved);
-	}
-	
-	public function test_it_finds_migration_directories() : void
-	{
-		$resolved = [];
-		
-		$this->helper->migrationDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('database/migrations'), $resolved);
-		$this->assertContains($this->module2->path('database/migrations'), $resolved);
-	}
-	
-	public function test_it_finds_models() : void
-	{
-		$this->artisan(MakeModel::class, [
-			'name' => 'TestModel',
-			'--module' => $this->module1->name,
-		]);
-		
-		$this->artisan(MakeModel::class, [
-			'name' => 'TestModel',
-			'--module' => $this->module2->name,
-		]);
-		
-		$resolved = [];
-		
-		$this->helper->modelFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
-		$this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
-	}
-	
-	public function test_it_finds_blade_components() : void
-	{
-		$this->artisan(MakeComponent::class, [
-			'name' => 'TestComponent',
-			'--module' => $this->module1->name,
-		]);
-		
-		$this->artisan(MakeComponent::class, [
-			'name' => 'TestComponent',
-			'--module' => $this->module2->name,
-		]);
-		
-		$resolved = [];
-		
-		$this->helper->bladeComponentFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
-		$this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
-	}
-	
-	public function test_it_finds_routes() : void
-	{
-		$resolved = [];
-		
-		$this->helper->routeFileFinder()->each(function(SplFileInfo $file) use (&$resolved) {
-			$resolved[] = $file->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
-		$this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
-	}
-	
-	public function test_it_finds_view_directories() : void
-	{
-		$resolved = [];
-		
-		$this->helper->viewDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('resources/views'), $resolved);
-		$this->assertContains($this->module2->path('resources/views'), $resolved);
-	}
-	
-	public function test_it_finds_lang_directories() : void
-	{
-		// These paths don't exist by default
-		$fs = new Filesystem();
-		$fs->makeDirectory($this->module1->path('resources/lang'));
-		$fs->makeDirectory($this->module2->path('resources/lang'));
-		
-		$resolved = [];
-		
-		$this->helper->langDirectoryFinder()->each(function(SplFileInfo $directory) use (&$resolved) {
-			$resolved[] = $directory->getPathname();
-		});
-		
-		$this->assertContains($this->module1->path('resources/lang'), $resolved);
-		$this->assertContains($this->module2->path('resources/lang'), $resolved);
-	}
+    use WritesToAppFilesystem;
+
+    protected $module1;
+
+    protected $module2;
+
+    protected $helper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->module1 = $this->makeModule('test-module');
+        $this->module2 = $this->makeModule('test-module-two');
+        $this->helper = new AutoDiscoveryHelper(
+            new ModuleRegistry($this->getBasePath() . '/app-modules', ''),
+            new Filesystem()
+        );
+    }
+
+    public function test_it_finds_commands(): void
+    {
+        $this->artisan(MakeCommand::class, [
+            'name' => 'TestCommand',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeCommand::class, [
+            'name' => 'TestCommand',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->commandFileFinder()->each(function (SplFileInfo $command) use (&$resolved) {
+            $resolved[] = $command->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/Console/Commands/TestCommand.php'), $resolved);
+        $this->assertContains($this->module2->path('src/Console/Commands/TestCommand.php'), $resolved);
+    }
+
+    public function test_it_finds_factory_directories(): void
+    {
+        $resolved = [];
+
+        $this->helper->factoryDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('database/factories'), $resolved);
+        $this->assertContains($this->module2->path('database/factories'), $resolved);
+    }
+
+    public function test_it_finds_migration_directories(): void
+    {
+        $resolved = [];
+
+        $this->helper->migrationDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('database/migrations'), $resolved);
+        $this->assertContains($this->module2->path('database/migrations'), $resolved);
+    }
+
+    public function test_it_finds_models(): void
+    {
+        $this->artisan(MakeModel::class, [
+            'name' => 'TestModel',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeModel::class, [
+            'name' => 'TestModel',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->modelFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/Models/TestModel.php'), $resolved);
+        $this->assertContains($this->module2->path('src/Models/TestModel.php'), $resolved);
+    }
+
+    public function test_it_finds_blade_components(): void
+    {
+        $this->artisan(MakeComponent::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeComponent::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->bladeComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
+        $this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
+    }
+
+    public function test_it_finds_routes(): void
+    {
+        $resolved = [];
+
+        $this->helper->routeFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path("routes/{$this->module1->name}-routes.php"), $resolved);
+        $this->assertContains($this->module2->path("routes/{$this->module2->name}-routes.php"), $resolved);
+    }
+
+    public function test_it_finds_view_directories(): void
+    {
+        $resolved = [];
+
+        $this->helper->viewDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('resources/views'), $resolved);
+        $this->assertContains($this->module2->path('resources/views'), $resolved);
+    }
+
+    public function test_it_finds_lang_directories(): void
+    {
+        // These paths don't exist by default
+        $fs = new Filesystem();
+        $fs->makeDirectory($this->module1->path('resources/lang'));
+        $fs->makeDirectory($this->module2->path('resources/lang'));
+
+        $resolved = [];
+
+        $this->helper->langDirectoryFinder()->each(function (SplFileInfo $directory) use (&$resolved) {
+            $resolved[] = $directory->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('resources/lang'), $resolved);
+        $this->assertContains($this->module2->path('resources/lang'), $resolved);
+    }
+
+    public function test_it_finds_livewire_component(): void
+    {
+
+        $this->artisan(MakeComponent::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module1->name,
+        ]);
+
+        $this->artisan(MakeComponent::class, [
+            'name' => 'TestComponent',
+            '--module' => $this->module2->name,
+        ]);
+
+        $resolved = [];
+
+        $this->helper->bladeComponentFileFinder()->each(function (SplFileInfo $file) use (&$resolved) {
+            $resolved[] = $file->getPathname();
+        });
+
+        $this->assertContains($this->module1->path('src/View/Components/TestComponent.php'), $resolved);
+        $this->assertContains($this->module2->path('src/View/Components/TestComponent.php'), $resolved);
+    }
 }

--- a/tests/Commands/Make/MakeLivewireTest.php
+++ b/tests/Commands/Make/MakeLivewireTest.php
@@ -2,11 +2,7 @@
 
 namespace InterNACHI\Modular\Tests\Commands\Make;
 
-use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
 use InterNACHI\Modular\Console\Commands\Make\MakeLivewire;
-use InterNACHI\Modular\Support\Facades\Modules;
-use InterNACHI\Modular\Support\ModularizedCommandsServiceProvider;
-use InterNACHI\Modular\Support\ModularServiceProvider;
 use InterNACHI\Modular\Tests\Concerns\TestsMakeCommands;
 use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
 use InterNACHI\Modular\Tests\TestCase;
@@ -16,73 +12,73 @@ use Livewire\LivewireServiceProvider;
 
 class MakeLivewireTest extends TestCase
 {
-    use WritesToAppFilesystem;
-    use TestsMakeCommands;
+	use WritesToAppFilesystem;
+	use TestsMakeCommands;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+	protected function setUp(): void
+	{
+		parent::setUp();
 
-        if (!class_exists(Livewire::class)) {
-            $this->markTestSkipped('Livewire is not installed.');
-        }
-    }
+		if (!class_exists(Livewire::class)) {
+			$this->markTestSkipped('Livewire is not installed.');
+		}
+	}
 
-    public function test_it_scaffolds_a_component_in_the_module_when_module_option_is_set(): void
-    {
-        $command = MakeLivewire::class;
-        $arguments = ['name' => 'TestLivewireComponent'];
-        $expected_path = 'src/Http/Livewire/TestLivewireComponent.php';
-        $expected_substrings = [
-            'namespace Modules\TestModule\Http\Livewire',
-            'class TestLivewireComponent',
-        ];
+	public function test_it_scaffolds_a_component_in_the_module_when_module_option_is_set(): void
+	{
+		$command = MakeLivewire::class;
+		$arguments = ['name' => 'TestLivewireComponent'];
+		$expected_path = 'src/Http/Livewire/TestLivewireComponent.php';
+		$expected_substrings = [
+			'namespace Modules\TestModule\Http\Livewire',
+			'class TestLivewireComponent',
+		];
 
-        $this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
+		$this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
 
-        $expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
-        $this->assertModuleFile($expected_view_path);
-    }
+		$expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
+		$this->assertModuleFile($expected_view_path);
+	}
 
-    public function test_it_scaffolds_a_component_with_nested_folders(): void
-    {
-        $command = MakeLivewire::class;
-        $arguments = ['name' => 'test.my-component/TestLivewireComponent'];
-        $expected_path = 'src/Http/Livewire/Test/MyComponent/TestLivewireComponent.php';
-        $expected_substrings = [
-            'namespace Modules\TestModule\Http\Livewire\Test\MyComponent',
-            'class TestLivewireComponent',
-        ];
+	public function test_it_scaffolds_a_component_with_nested_folders(): void
+	{
+		$command = MakeLivewire::class;
+		$arguments = ['name' => 'test.my-component/TestLivewireComponent'];
+		$expected_path = 'src/Http/Livewire/Test/MyComponent/TestLivewireComponent.php';
+		$expected_substrings = [
+			'namespace Modules\TestModule\Http\Livewire\Test\MyComponent',
+			'class TestLivewireComponent',
+		];
 
-        $this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
+		$this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
 
-        $expected_view_path = 'resources/views/livewire/test/my-component/test-livewire-component.blade.php';
-        $this->assertModuleFile($expected_view_path);
-    }
+		$expected_view_path = 'resources/views/livewire/test/my-component/test-livewire-component.blade.php';
+		$this->assertModuleFile($expected_view_path);
+	}
 
-    public function test_it_scaffolds_a_component_in_the_app_when_module_option_is_missing(): void
-    {
-        $command = MakeLivewire::class;
-        $arguments = ['name' => 'TestLivewireComponent'];
-        $expected_path = 'app/Http/Livewire/TestLivewireComponent.php';
-        $expected_substrings = [
-            'namespace App\Http\Livewire',
-            'class TestLivewireComponent',
-        ];
+	public function test_it_scaffolds_a_component_in_the_app_when_module_option_is_missing(): void
+	{
+		$command = MakeLivewire::class;
+		$arguments = ['name' => 'TestLivewireComponent'];
+		$expected_path = 'app/Http/Livewire/TestLivewireComponent.php';
+		$expected_substrings = [
+			'namespace App\Http\Livewire',
+			'class TestLivewireComponent',
+		];
 
-        $this->assertBaseCommandResults($command, $arguments, $expected_path, $expected_substrings);
+		$this->assertBaseCommandResults($command, $arguments, $expected_path, $expected_substrings);
 
-        $expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
-        $this->assertBaseFile($expected_view_path);
-    }
+		$expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
+		$this->assertBaseFile($expected_view_path);
+	}
 
-    protected function getPackageProviders($app)
-    {
-        return array_merge(parent::getPackageProviders($app), [LivewireServiceProvider::class]);
-    }
+	protected function getPackageProviders($app)
+	{
+		return array_merge(parent::getPackageProviders($app), [LivewireServiceProvider::class]);
+	}
 
-    protected function getPackageAliases($app)
-    {
-        return array_merge(parent::getPackageAliases($app), ['Livewire' => LivewireManager::class]);
-    }
+	protected function getPackageAliases($app)
+	{
+		return array_merge(parent::getPackageAliases($app), ['Livewire' => LivewireManager::class]);
+	}
 }

--- a/tests/Commands/Make/MakeLivewireTest.php
+++ b/tests/Commands/Make/MakeLivewireTest.php
@@ -16,57 +16,73 @@ use Livewire\LivewireServiceProvider;
 
 class MakeLivewireTest extends TestCase
 {
-	use WritesToAppFilesystem;
-	use TestsMakeCommands;
-	
-	protected function setUp() : void
-	{
-		parent::setUp();
-		
-		if (!class_exists(Livewire::class)) {
-			$this->markTestSkipped('Livewire is not installed.');
-		}
-	}
-	
-	public function test_it_scaffolds_a_component_in_the_module_when_module_option_is_set(): void
-	{
-		$command = MakeLivewire::class;
-		$arguments = ['name' => 'TestLivewireComponent'];
-		$expected_path = 'src/Http/Livewire/TestLivewireComponent.php';
-		$expected_substrings = [
-			'namespace Modules\TestModule\Http\Livewire',
-			'class TestLivewireComponent',
-		];
-		
-		$this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
-		
-		$expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
-		$this->assertModuleFile($expected_view_path);
-	}
-	
-	public function test_it_scaffolds_a_component_in_the_app_when_module_option_is_missing(): void
-	{
-		$command = MakeLivewire::class;
-		$arguments = ['name' => 'TestLivewireComponent'];
-		$expected_path = 'app/Http/Livewire/TestLivewireComponent.php';
-		$expected_substrings = [
-			'namespace App\Http\Livewire',
-			'class TestLivewireComponent',
-		];
-		
-		$this->assertBaseCommandResults($command, $arguments, $expected_path, $expected_substrings);
-		
-		$expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
-		$this->assertBaseFile($expected_view_path);
-	}
-	
-	protected function getPackageProviders($app)
-	{
-		return array_merge(parent::getPackageProviders($app), [LivewireServiceProvider::class]);
-	}
-	
-	protected function getPackageAliases($app)
-	{
-		return array_merge(parent::getPackageAliases($app), ['Livewire' => LivewireManager::class]);
-	}
+    use WritesToAppFilesystem;
+    use TestsMakeCommands;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists(Livewire::class)) {
+            $this->markTestSkipped('Livewire is not installed.');
+        }
+    }
+
+    public function test_it_scaffolds_a_component_in_the_module_when_module_option_is_set(): void
+    {
+        $command = MakeLivewire::class;
+        $arguments = ['name' => 'TestLivewireComponent'];
+        $expected_path = 'src/Http/Livewire/TestLivewireComponent.php';
+        $expected_substrings = [
+            'namespace Modules\TestModule\Http\Livewire',
+            'class TestLivewireComponent',
+        ];
+
+        $this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
+
+        $expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
+        $this->assertModuleFile($expected_view_path);
+    }
+
+    public function test_it_scaffolds_a_component_with_nested_folders(): void
+    {
+        $command = MakeLivewire::class;
+        $arguments = ['name' => 'test.my-component/TestLivewireComponent'];
+        $expected_path = 'src/Http/Livewire/Test/MyComponent/TestLivewireComponent.php';
+        $expected_substrings = [
+            'namespace Modules\TestModule\Http\Livewire\Test\MyComponent',
+            'class TestLivewireComponent',
+        ];
+
+        $this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
+
+        $expected_view_path = 'resources/views/livewire/test/my-component/test-livewire-component.blade.php';
+        $this->assertModuleFile($expected_view_path);
+    }
+
+    public function test_it_scaffolds_a_component_in_the_app_when_module_option_is_missing(): void
+    {
+        $command = MakeLivewire::class;
+        $arguments = ['name' => 'TestLivewireComponent'];
+        $expected_path = 'app/Http/Livewire/TestLivewireComponent.php';
+        $expected_substrings = [
+            'namespace App\Http\Livewire',
+            'class TestLivewireComponent',
+        ];
+
+        $this->assertBaseCommandResults($command, $arguments, $expected_path, $expected_substrings);
+
+        $expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
+        $this->assertBaseFile($expected_view_path);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return array_merge(parent::getPackageProviders($app), [LivewireServiceProvider::class]);
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return array_merge(parent::getPackageAliases($app), ['Livewire' => LivewireManager::class]);
+    }
 }

--- a/tests/Commands/Make/MakeLivewireTest.php
+++ b/tests/Commands/Make/MakeLivewireTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace InterNACHI\Modular\Tests\Commands\Make;
+
+use InterNACHI\Modular\Console\Commands\Make\MakeComponent;
+use InterNACHI\Modular\Console\Commands\Make\MakeLivewire;
+use InterNACHI\Modular\Support\Facades\Modules;
+use InterNACHI\Modular\Support\ModularizedCommandsServiceProvider;
+use InterNACHI\Modular\Support\ModularServiceProvider;
+use InterNACHI\Modular\Tests\Concerns\TestsMakeCommands;
+use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
+use InterNACHI\Modular\Tests\TestCase;
+use Livewire\Livewire;
+use Livewire\LivewireManager;
+use Livewire\LivewireServiceProvider;
+
+class MakeLivewireTest extends TestCase
+{
+	use WritesToAppFilesystem;
+	use TestsMakeCommands;
+	
+	protected function setUp() : void
+	{
+		parent::setUp();
+		
+		if (!class_exists(Livewire::class)) {
+			$this->markTestSkipped('Livewire is not installed.');
+		}
+	}
+	
+	public function test_it_scaffolds_a_component_in_the_module_when_module_option_is_set(): void
+	{
+		$command = MakeLivewire::class;
+		$arguments = ['name' => 'TestLivewireComponent'];
+		$expected_path = 'src/Http/Livewire/TestLivewireComponent.php';
+		$expected_substrings = [
+			'namespace Modules\TestModule\Http\Livewire',
+			'class TestLivewireComponent',
+		];
+		
+		$this->assertModuleCommandResults($command, $arguments, $expected_path, $expected_substrings);
+		
+		$expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
+		$this->assertModuleFile($expected_view_path);
+	}
+	
+	public function test_it_scaffolds_a_component_in_the_app_when_module_option_is_missing(): void
+	{
+		$command = MakeLivewire::class;
+		$arguments = ['name' => 'TestLivewireComponent'];
+		$expected_path = 'app/Http/Livewire/TestLivewireComponent.php';
+		$expected_substrings = [
+			'namespace App\Http\Livewire',
+			'class TestLivewireComponent',
+		];
+		
+		$this->assertBaseCommandResults($command, $arguments, $expected_path, $expected_substrings);
+		
+		$expected_view_path = 'resources/views/livewire/test-livewire-component.blade.php';
+		$this->assertBaseFile($expected_view_path);
+	}
+	
+	protected function getPackageProviders($app)
+	{
+		return array_merge(parent::getPackageProviders($app), [LivewireServiceProvider::class]);
+	}
+	
+	protected function getPackageAliases($app)
+	{
+		return array_merge(parent::getPackageAliases($app), ['Livewire' => LivewireManager::class]);
+	}
+}


### PR DESCRIPTION
Added livewire auto-discovery support.

You need to create the Livewire folder within the src/Http folder 

Just an example of how to render the view for the component is the same namespace "schema" as returning views in regular controllers.

```
class ExampleLivewireComponent extends Component
{

    public function render()
    {
        return view('$moduleName::livewire.example');
    }
}

```