### PR TITLE
Don't autoload test php files on production

### DIFF
--- a/stubs/composer-stub-latest.json
+++ b/stubs/composer-stub-latest.json
@@ -8,9 +8,13 @@
 	"autoload": {
 		"psr-4": {
 			"StubModuleNamespace\\StubClassNamePrefix\\": "src/",
-			"StubModuleNamespace\\StubClassNamePrefix\\Tests\\": "tests/",
 			"StubModuleNamespace\\StubClassNamePrefix\\Database\\Factories\\": "database/factories/",
 			"StubModuleNamespace\\StubClassNamePrefix\\Database\\Seeders\\": "database/seeders/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"StubModuleNamespace\\StubClassNamePrefix\\Tests\\": "tests/"
 		}
 	},
 	"minimum-stability": "stable",
@@ -22,3 +26,4 @@
 		}
 	}
 }
+-


### PR DESCRIPTION
In production we do not need or want to import all the test PHP files every time Laravel is initialised.

It could be argued that Factories are not normally used in Production, and possibly not Seeds either, however I can imagine scenarios where this could easily be the case (or where not loading them will cause other functionality to fail).