### PR TITLE
Use autoload-dev for tests, factories and seeders

### DIFF
--- a/stubs/composer-stub-latest.json
+++ b/stubs/composer-stub-latest.json
@@ -7,7 +7,11 @@
 	"require": {},
 	"autoload": {
 		"psr-4": {
-			"StubModuleNamespace\\StubClassNamePrefix\\": "src/",
+			"StubModuleNamespace\\StubClassNamePrefix\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
 			"StubModuleNamespace\\StubClassNamePrefix\\Tests\\": "tests/",
 			"StubModuleNamespace\\StubClassNamePrefix\\Database\\Factories\\": "database/factories/",
 			"StubModuleNamespace\\StubClassNamePrefix\\Database\\Seeders\\": "database/seeders/"

--- a/stubs/composer-stub-v7.json
+++ b/stubs/composer-stub-v7.json
@@ -6,10 +6,6 @@
 	"license": "proprietary",
 	"require": {},
 	"autoload": {
-		"classmap": [
-			"database/seeds",
-			"database/factories"
-		],
 		"psr-4": {
 			"StubModuleNamespace\\StubClassNamePrefix\\": "src/"
 		}
@@ -17,7 +13,11 @@
 	"autoload-dev": {
 		"psr-4": {
 			"StubModuleNamespace\\StubClassNamePrefix\\Tests\\": "tests/"
-		}
+		},
+		"classmap": [
+			"database/seeds",
+			"database/factories"
+		]
 	},
 	"minimum-stability": "stable",
 	"extra": {

--- a/stubs/composer-stub-v7.json
+++ b/stubs/composer-stub-v7.json
@@ -11,7 +11,11 @@
 			"database/factories"
 		],
 		"psr-4": {
-			"StubModuleNamespace\\StubClassNamePrefix\\": "src/",
+			"StubModuleNamespace\\StubClassNamePrefix\\": "src/"
+		}
+	},
+	"autoload-dev": {
+		"psr-4": {
 			"StubModuleNamespace\\StubClassNamePrefix\\Tests\\": "tests/"
 		}
 	},

--- a/tests/Commands/Make/MakeModuleTest.php
+++ b/tests/Commands/Make/MakeModuleTest.php
@@ -37,15 +37,15 @@ class MakeModuleTest extends TestCase
 		
 		$this->assertEquals("modules/{$module_name}", $composer_contents['name']);
 		$this->assertEquals('src/', $composer_contents['autoload']['psr-4']['Modules\\TestModule\\']);
-		$this->assertEquals('tests/', $composer_contents['autoload']['psr-4']['Modules\\TestModule\\Tests\\']);
+		$this->assertEquals('tests/', $composer_contents['autoload-dev']['psr-4']['Modules\\TestModule\\Tests\\']);
 		$this->assertContains('Modules\\TestModule\\Providers\\TestModuleServiceProvider', $composer_contents['extra']['laravel']['providers']);
 		
 		if (version_compare($this->app->version(), '8.0.0', '>=')) {
-			$this->assertEquals('database/factories/', $composer_contents['autoload']['psr-4']['Modules\\TestModule\\Database\\Factories\\']);
-			$this->assertEquals('database/seeders/', $composer_contents['autoload']['psr-4']['Modules\\TestModule\\Database\\Seeders\\']);
+			$this->assertEquals('database/factories/', $composer_contents['autoload-dev']['psr-4']['Modules\\TestModule\\Database\\Factories\\']);
+			$this->assertEquals('database/seeders/', $composer_contents['autoload-dev']['psr-4']['Modules\\TestModule\\Database\\Seeders\\']);
 		} else {
-			$this->assertContains('database/factories', $composer_contents['autoload']['classmap']);
-			$this->assertContains('database/seeds', $composer_contents['autoload']['classmap']);
+			$this->assertContains('database/factories', $composer_contents['autoload-dev']['classmap']);
+			$this->assertContains('database/seeds', $composer_contents['autoload-dev']['classmap']);
 		}
 		
 		$app_composer_file = $this->getBasePath().'/composer.json';


### PR DESCRIPTION
### Why
Current stubs autoload all tests, factories and seeders into the composer autoload.  We should instead use `autoload-dev` which excludes these files when running `composer install --no-dev`