### PR TITLE
fixed make command to stop removing signature

### DIFF
--- a/src/Console/Commands/Make/MakeCommand.php
+++ b/src/Console/Commands/Make/MakeCommand.php
@@ -17,8 +17,8 @@ class MakeCommand extends ConsoleMakeCommand
 		if ($module && (! $this->option('command') || 'command:name' === $this->option('command'))) {
 			$cli_name = Str::of($name)->classBasename()->kebab();
 
-            $find = [
-                "command:name",
+			$find = [
+				'command:name',
 				"app:{$cli_name}",
 			];
 			

--- a/src/Console/Commands/Make/MakeCommand.php
+++ b/src/Console/Commands/Make/MakeCommand.php
@@ -16,10 +16,9 @@ class MakeCommand extends ConsoleMakeCommand
 		
 		if ($module && (! $this->option('command') || 'command:name' === $this->option('command'))) {
 			$cli_name = Str::of($name)->classBasename()->kebab();
-			
-			$find = [
-				"signature = 'command:name'",
-				"signature = 'app:{$cli_name}'",
+
+            $find = [
+				"app:{$cli_name}",
 			];
 			
 			$stub = str_replace($find, "{$module->name}:{$cli_name}", $stub);

--- a/src/Console/Commands/Make/MakeCommand.php
+++ b/src/Console/Commands/Make/MakeCommand.php
@@ -18,6 +18,7 @@ class MakeCommand extends ConsoleMakeCommand
 			$cli_name = Str::of($name)->classBasename()->kebab();
 
             $find = [
+                "command:name",
 				"app:{$cli_name}",
 			];
 			


### PR DESCRIPTION
```bash
make:command DemoCommand --module=demo
```

was creating a signature in the format of:

```
protected $demo:demo-command;
```

but should be:

```
protected $signature = 'demo:demo-command';
```

I've edited the find array to only look and replace `command:name` and `app:{$cli_name}` 