### PR TITLE
FIX Livewire Make Command Compatibility

### DIFF
--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Livewire\Features\SupportConsoleCommands\Commands\MakeCommand;
 use Livewire\Livewire;
-use Livewire\LivewireComponentsFinder;
 
 if (class_exists(MakeCommand::class)) {
 	class MakeLivewire extends MakeCommand
@@ -32,14 +31,14 @@ if (class_exists(MakeCommand::class)) {
 					? '/tmp/storage/bootstrap/cache/livewire-components.php'
 					: $app->bootstrapPath('cache/livewire-components.php');
 
-                if (class_exists(LivewireComponentsFinder::class)) {
-                    $componentsFinder = new LivewireComponentsFinder(
+                if (class_exists("Livewire\LivewireComponentsFinder")) {
+                    $componentsFinder = new \Livewire\LivewireComponentsFinder(
                         new Filesystem(),
                         Config::get('livewire.manifest_path') ?? $defaultManifestPath,
                         $module->path('src/Http/Livewire')
                     );
 
-                    $app->instance(LivewireComponentsFinder::class, $componentsFinder);
+                    $app->instance(\Livewire\LivewireComponentsFinder::class, $componentsFinder);
                 }
 
 			}

--- a/src/Console/Commands/Make/MakeLivewire.php
+++ b/src/Console/Commands/Make/MakeLivewire.php
@@ -6,7 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
-use Livewire\Commands\MakeCommand;
+use Livewire\Features\SupportConsoleCommands\Commands\MakeCommand;
 use Livewire\Livewire;
 use Livewire\LivewireComponentsFinder;
 
@@ -14,36 +14,39 @@ if (class_exists(MakeCommand::class)) {
 	class MakeLivewire extends MakeCommand
 	{
 		use Modularize;
-		
+
 		public function getAliases(): array
 		{
 			return ['make:livewire', 'livewire:make'];
 		}
-		
+
 		public function handle()
 		{
 			if ($module = $this->module()) {
 				Config::set('livewire.class_namespace', $module->qualify('Http\\Livewire'));
 				Config::set('livewire.view_path', $module->path('resources/views/livewire'));
-				
+
 				$app = $this->getLaravel();
-				
+
 				$defaultManifestPath = $app['livewire']->isRunningServerless()
 					? '/tmp/storage/bootstrap/cache/livewire-components.php'
 					: $app->bootstrapPath('cache/livewire-components.php');
-				
-				$componentsFinder = new LivewireComponentsFinder(
-					new Filesystem(),
-					Config::get('livewire.manifest_path') ?? $defaultManifestPath,
-					$module->path('src/Http/Livewire')
-				);
-				
-				$app->instance(LivewireComponentsFinder::class, $componentsFinder);
+
+                if (class_exists(LivewireComponentsFinder::class)) {
+                    $componentsFinder = new LivewireComponentsFinder(
+                        new Filesystem(),
+                        Config::get('livewire.manifest_path') ?? $defaultManifestPath,
+                        $module->path('src/Http/Livewire')
+                    );
+
+                    $app->instance(LivewireComponentsFinder::class, $componentsFinder);
+                }
+
 			}
-			
+
 			parent::handle();
 		}
-		
+
 		protected function createClass($force = false, $inline = false)
 		{
 			if ($module = $this->module()) {
@@ -51,37 +54,37 @@ if (class_exists(MakeCommand::class)) {
 					->split('/[.\/(\\\\)]+/')
 					->map([Str::class, 'studly'])
 					->join(DIRECTORY_SEPARATOR);
-				
+
 				$classPath = $module->path('src/Http/Livewire/'.$name.'.php');
-				
+
 				if (File::exists($classPath) && ! $force) {
 					$this->line("<options=bold,reverse;fg=red> WHOOPS-IE-TOOTLES </> 😳 \n");
 					$this->line("<fg=red;options=bold>Class already exists:</> {$this->parser->relativeClassPath()}");
-					
+
 					return false;
 				}
-				
+
 				$this->ensureDirectoryExists($classPath);
-				
+
 				File::put($classPath, $this->parser->classContents($inline));
-				
+
 				$component_name = Str::of($name)
 					->explode('/')
 					->filter()
 					->map([Str::class, 'kebab'])
 					->implode('.');
-				
+
 				$fully_qualified_component = Str::of($this->argument('name'))
 					->prepend('Http/Livewire/')
 					->split('/[.\/(\\\\)]+/')
 					->map([Str::class, 'studly'])
 					->join('\\');
-				
+
 				Livewire::component("{$module->name}::{$component_name}", $module->qualify($fully_qualified_component));
-				
+
 				return $classPath;
 			}
-			
+
 			return parent::createClass($force, $inline);
 		}
 	}

--- a/src/Support/ModularizedCommandsServiceProvider.php
+++ b/src/Support/ModularizedCommandsServiceProvider.php
@@ -31,7 +31,7 @@ use InterNACHI\Modular\Console\Commands\Make\MakeResource;
 use InterNACHI\Modular\Console\Commands\Make\MakeRule;
 use InterNACHI\Modular\Console\Commands\Make\MakeSeeder;
 use InterNACHI\Modular\Console\Commands\Make\MakeTest;
-use Livewire\Commands as Livewire;
+use Livewire\Features\SupportConsoleCommands\Commands as Livewire;
 
 class ModularizedCommandsServiceProvider extends ServiceProvider
 {
@@ -60,7 +60,7 @@ class ModularizedCommandsServiceProvider extends ServiceProvider
 		'command.component.make' => MakeComponent::class,
 		'command.seed' => SeedCommand::class,
 	];
-	
+
 	public function register(): void
 	{
 		// Register our overrides via the "booted" event to ensure that we override
@@ -74,7 +74,7 @@ class ModularizedCommandsServiceProvider extends ServiceProvider
 			});
 		});
 	}
-	
+
 	protected function registerMakeCommandOverrides()
 	{
 		foreach ($this->overrides as $alias => $class_name) {
@@ -82,30 +82,30 @@ class ModularizedCommandsServiceProvider extends ServiceProvider
 			$this->app->singleton(get_parent_class($class_name), $class_name);
 		}
 	}
-	
+
 	protected function registerMigrationCommandOverrides()
 	{
 		// Laravel 8
 		$this->app->singleton('command.migrate.make', function($app) {
 			return new MakeMigration($app['migration.creator'], $app['composer']);
 		});
-		
+
 		// Laravel 9
 		$this->app->singleton(OriginalMakeMigrationCommand::class, function($app) {
 			return new MakeMigration($app['migration.creator'], $app['composer']);
 		});
 	}
-	
+
 	protected function registerLivewireOverrides(Artisan $artisan)
 	{
 		// Don't register commands if Livewire isn't installed
 		if (! class_exists(Livewire\MakeCommand::class)) {
 			return;
 		}
-		
+
 		// Replace the resolved command with our subclass
 		$artisan->resolveCommands([MakeLivewire::class]);
-		
+
 		// Ensure that if 'make:livewire' or 'livewire:make' is resolved from the container
 		// in the future, our subclass is used instead
 		$this->app->extend(Livewire\MakeCommand::class, function() {


### PR DESCRIPTION
Hi, i'm start using this package not long time ago and i detect some bugs in make:livewire command with error " The "--module" option does not exist." .
![image](https://github.com/InterNACHI/modular/assets/114736230/4d7d1b15-1bae-43ae-a6a5-d1008e2a390c)

I made some adjustments to improve compatibility with v3 of livewire, it was just a few namespace changes, I hope it can contribute to the project and be useful so that others who use it can enjoy this command!
Result:
![image](https://github.com/InterNACHI/modular/assets/114736230/e65f0369-a0e3-424a-9ec6-d9f1188d9700)