### PR TITLE
Support default Livewire V3 location

### DIFF
--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -93,15 +93,16 @@ class AutoDiscoveryHelper
 	
 	public function livewireComponentFileFinder(): FinderCollection
 	{
-		$finder = FinderCollection::forFiles()
-			->name('*.php');
+		$directory = $this->base_path.'/*/src';
 
-		$location_v2 = $finder->inOrEmpty($this->base_path.'/*/src/Http/Livewire');
-
-		if ($location_v2->isNotEmpty()) {
-			return $location_v2;
+		if (str_contains(config('livewire.class_namespace'), '\\Http\\')) {
+			$directory .= '/Http';
 		}
 
-		return $finder->inOrEmpty($this->base_path.'/*/src/Livewire');
+		$directory .= '/Livewire';
+
+		return FinderCollection::forFiles()
+			->name('*.php')
+			->inOrEmpty($directory);
 	}
 }

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -98,7 +98,7 @@ class AutoDiscoveryHelper
 
 		$location_v2 = $finder->inOrEmpty($this->base_path.'/*/src/Http/Livewire');
 
-		if($location_v2->isNotEmpty()) {
+		if ($location_v2->isNotEmpty()) {
 			return $location_v2;
 		}
 

--- a/src/Support/AutoDiscoveryHelper.php
+++ b/src/Support/AutoDiscoveryHelper.php
@@ -93,8 +93,15 @@ class AutoDiscoveryHelper
 	
 	public function livewireComponentFileFinder(): FinderCollection
 	{
-		return FinderCollection::forFiles()
-			->name('*.php')
-			->inOrEmpty($this->base_path.'/*/src/Http/Livewire');
+		$finder = FinderCollection::forFiles()
+			->name('*.php');
+
+		$location_v2 = $finder->inOrEmpty($this->base_path.'/*/src/Http/Livewire');
+
+		if($location_v2->isNotEmpty()) {
+			return $location_v2;
+		}
+
+		return $finder->inOrEmpty($this->base_path.'/*/src/Livewire');
 	}
 }


### PR DESCRIPTION
In Livewire v3 the default location for components is just in a root `Livewire` directory, not nested under `Http`