### PR TITLE
Add void return type to ServiceProvider stub

### DIFF
--- a/stubs/ServiceProvider.php
+++ b/stubs/ServiceProvider.php
@@ -6,11 +6,11 @@ use Illuminate\Support\ServiceProvider;
 
 class StubClassNamePrefixServiceProvider extends ServiceProvider
 {
-	public function register() : void
+	public function register(): void
 	{
 	}
 	
-	public function boot() : void
+	public function boot(): void
 	{
 	}
 }

--- a/stubs/ServiceProvider.php
+++ b/stubs/ServiceProvider.php
@@ -6,11 +6,11 @@ use Illuminate\Support\ServiceProvider;
 
 class StubClassNamePrefixServiceProvider extends ServiceProvider
 {
-	public function register()
+	public function register() : void
 	{
 	}
 	
-	public function boot()
+	public function boot() : void
 	{
 	}
 }


### PR DESCRIPTION
Judging from the tests coverage inside `.github/workflows`, `php 8.*` is being used, which has the support for `:void` return types. 
Without it, it fails on `phpstan level 9`. Besides, new laravel applications comes with `:void` return type for both app service provider methods.
