### PR TITLE
Resolves #75 Command $signature is being replaced with modular_name:command

### DIFF
--- a/src/Console/Commands/Make/MakeCommand.php
+++ b/src/Console/Commands/Make/MakeCommand.php
@@ -22,7 +22,7 @@ class MakeCommand extends ConsoleMakeCommand
 				"signature = 'app:{$cli_name}'",
 			];
 			
-			$stub = str_replace($find, "{$module->name}:{$cli_name}", $stub);
+			$stub = str_replace($find, "signature = '{$module->name}:{$cli_name}'", $stub);
 		}
 		
 		return $stub;


### PR DESCRIPTION
Should Resolve #75 


Tested with both 

```bash
php artisan make:command TestCommand --module="test-module"
```
and

```bash
php artisan make:command TestCommand --module="test-module" --command="my:test:command"
```

Both works flawlessly