### PR TITLE
Add option to disable module discovery

### DIFF
--- a/config.php
+++ b/config.php
@@ -77,7 +77,7 @@ return [
 	| ],
 	*/
 	
-	'stubs' => null,
+    'stubs' => null,
 	
 	/*
 	|--------------------------------------------------------------------------
@@ -90,5 +90,27 @@ return [
 	| the presence of event discovery.
 	*/
 	
-	'should_discover_events' => null,
+    'should_discover_events' => null,
+
+    /*
+	|--------------------------------------------------------------------------
+    | Prevent automatic discovery of module components
+	|--------------------------------------------------------------------------
+    |
+    | This package automatically discovers different componets from the modules
+    | like commands, routes, views, translations, blade and livewire
+    | components, and breadcrumbs. If you want to prevent automatic discovery
+    | of specific components you can list them here in the 'dont_discover'
+    | array.
+    */
+
+    'dont_discover' => [
+        // 'commands',
+        // 'routes',
+        // 'views',
+        // 'translations',
+        // 'blade_components',
+        // 'livewire_components',
+        // 'breadcrumbs',
+    ],
 ];

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -73,15 +73,35 @@ class ModularServiceProvider extends ServiceProvider
 	
 	public function boot(): void
 	{
-		$this->publishVendorFiles();
-		$this->bootPackageCommands();
-		
-		$this->bootRoutes();
-		$this->bootBreadcrumbs();
-		$this->bootViews();
-		$this->bootBladeComponents();
-		$this->bootTranslations();
-		$this->bootLivewireComponents();
+        $this->publishVendorFiles();
+
+        if ($this->shouldDiscover('commands')) {
+            $this->bootPackageCommands();
+        }
+
+        if ($this->shouldDiscover('routes')) {
+            $this->bootRoutes();
+        }
+
+        if ($this->shouldDiscover('breadcrumbs')) {
+            $this->bootBreadcrumbs();
+        }
+
+        if ($this->shouldDiscover('views')) {
+            $this->bootViews();
+        }
+
+        if ($this->shouldDiscover('blade_components')) {
+            $this->bootBladeComponents();
+        }
+
+        if ($this->shouldDiscover('translations')) {
+            $this->bootTranslations();
+        }
+
+        if ($this->shouldDiscover('livewire_components')) {
+            $this->bootLivewireComponents();
+        }
 	}
 	
 	protected function registry(): ModuleRegistry
@@ -92,7 +112,12 @@ class ModularServiceProvider extends ServiceProvider
 	protected function autoDiscoveryHelper(): AutoDiscoveryHelper
 	{
 		return $this->auto_discovery_helper ??= $this->app->make(AutoDiscoveryHelper::class);
-	}
+    }
+
+    protected function shouldDiscover(string $component): bool
+    {
+        return ! in_array($component,  config('app-modules.dont_discover', []));
+    }
 	
 	protected function publishVendorFiles(): void
 	{
@@ -102,7 +127,7 @@ class ModularServiceProvider extends ServiceProvider
 	}
 	
 	protected function bootPackageCommands(): void
-	{
+    {
 		if (! $this->app->runningInConsole()) {
 			return;
 		}


### PR DESCRIPTION
This pull request refines the automatic discovery logic for various components within the modules. The changes introduce more flexibility by allowing users to specify which components should be automatically discovered and registered.

When decoupling modules to separate packages the autodiscover logic has to be implemented into the package itself so for my use case it's better to have autodiscovery disabled by default and implemented in the package through service prividers and the `extra` key in `composer.json`. This way, modules can be converted into packages at any time without any extra changes needed