### PR TITLE
Add modules_path helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ Both filenames and file contents support a number of placeholders. These include
  - `StubFullyQualifiedTestCaseBase`
  - `StubTestCaseBase`
 
+#### Modules Path Helper
+
+The `modules_path` function returns the fully qualified path to your modules' directory. You may also use the `modules_path` function to generate a fully qualified path to a given file relative to the modules' directory. 
+
+This function works similarly to the existing `app_path` or `storage_path` helpers, allowing you to generate paths relative to the modules' directory effortlessly.
+
 ## Comparison to `nwidart/laravel-modules`
 
 [Laravel Modules](https://nwidart.com/laravel-modules) is a great package that’s been

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,10 @@
     "autoload": {
         "psr-4": {
             "InterNACHI\\Modular\\": "src/"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,16 @@
+<?php 
+
+if (! function_exists('modules_path')) {
+    /**
+     * Get the path to the modules folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function modules_path($path = '')
+    {
+        $directory_name = config('app-modules.modules_directory', 'app-modules');
+        $path = base_path($directory_name . DIRECTORY_SEPARATOR . ltrim($path, '/\\'));
+        return str_replace('\\', '/', rtrim($path, '/\\'));
+    }
+}

--- a/tests/ModulesPathTest.php
+++ b/tests/ModulesPathTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace InterNACHI\Modular\Tests;
+
+use Illuminate\Support\Facades\Config;
+
+class ModulesPathTest extends TestCase
+{
+    public function testModulesPathWithoutArgument()
+    {
+        Config::set('app-modules.modules_directory', 'app-modules');
+
+        $expected = str_replace('\\', '/', base_path('app-modules'));
+
+        $this->assertEquals($expected, modules_path());
+    }
+
+    public function testModulesPathWithArgument()
+    {
+        Config::set('app-modules.modules_directory', 'app-modules');
+
+        $expected = str_replace('\\', '/', base_path('app-modules/module/test.php'));
+
+        $this->assertEquals($expected, modules_path('/module/test.php'));
+    }
+}


### PR DESCRIPTION
This PR adds the `modules_path` helper function to provide the fully qualified modules path, resolving the path using the config setting. 

The function is autoloaded with composer, as any other standard helper function.

A small description has been added in the README and a test has been included.

It is useful to those who use this package across different projects where the modules' folder is named differently and you do not have to hard-code the path to the modules. 

### Example
It works exactly has many other laravel path helper functions:
```php 
$path = modules_path('module1/file.php');
```