### PR TITLE
Change name cache file

### DIFF
--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -50,7 +50,7 @@ class ModularServiceProvider extends ServiceProvider
 		$this->app->singleton(ModuleRegistry::class, function() {
 			return new ModuleRegistry(
 				$this->getModulesBasePath(),
-				$this->app->bootstrapPath('cache/modules.php')
+				$this->app->bootstrapPath('cache/app_modules.php')
 			);
 		});
 		

--- a/tests/Commands/ModulesCacheTest.php
+++ b/tests/Commands/ModulesCacheTest.php
@@ -17,7 +17,7 @@ class ModulesCacheTest extends TestCase
 		
 		$this->artisan(ModulesCache::class);
 		
-		$expected_path = $this->getBasePath().$this->normalizeDirectorySeparators('bootstrap/cache/modules.php');
+		$expected_path = $this->getBasePath().$this->normalizeDirectorySeparators('bootstrap/cache/app_modules.php');
 		
 		$this->assertFileExists($expected_path);
 		

--- a/tests/Commands/ModulesClearTest.php
+++ b/tests/Commands/ModulesClearTest.php
@@ -15,7 +15,7 @@ class ModulesClearTest extends TestCase
 	{
 		$this->artisan(ModulesCache::class);
 		
-		$expected_path = $this->getBasePath().$this->normalizeDirectorySeparators('bootstrap/cache/modules.php');
+		$expected_path = $this->getBasePath().$this->normalizeDirectorySeparators('bootstrap/cache/app_modules.php');
 		
 		$this->assertFileExists($expected_path);
 		


### PR DESCRIPTION
There is a new conflict with the module nWidart/laravel-modules. They are also using this file. 
And this module already has the config file names app-modules, so i thought i would also bring some nice consistency