### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Exceptions/CannotFindModuleForPathException.php
+++ b/src/Exceptions/CannotFindModuleForPathException.php
@@ -6,7 +6,7 @@ use Throwable;
 
 class CannotFindModuleForPathException extends Exception
 {
-	public function __construct(string $path, Throwable $previous = null)
+	public function __construct(string $path, ?Throwable $previous = null)
 	{
 		parent::__construct("Unable to determine module for '{$path}'", 0, $previous);
 	}

--- a/src/Support/ModuleConfig.php
+++ b/src/Support/ModuleConfig.php
@@ -32,7 +32,7 @@ class ModuleConfig implements Arrayable
 	public function __construct(
 		public string $name,
 		public string $base_path,
-		Collection $namespaces = null
+		?Collection $namespaces = null
 	) {
 		$this->namespaces = $namespaces ?? new Collection();
 	}

--- a/src/Support/ModuleRegistry.php
+++ b/src/Support/ModuleRegistry.php
@@ -27,7 +27,7 @@ class ModuleRegistry
 		return $this->cache_path;
 	}
 	
-	public function module(string $name = null): ?ModuleConfig
+	public function module(?string $name = null): ?ModuleConfig
 	{
 		// We want to allow for gracefully handling empty/null names
 		return $name


### PR DESCRIPTION
Fix PHP 8.4 deprecations and add nullable type declaration for default null value

Not included in this PR but changes that you might want to add:
- add the php-cs-fixer rule for this which is named: `nullable_type_declaration_for_default_null_value`
- update GitHub workflow to test with PHP 8.4