### PR TITLE
Using conventional directories for default test

### DIFF
--- a/src/Console/Commands/Make/MakeModule.php
+++ b/src/Console/Commands/Make/MakeModule.php
@@ -333,7 +333,7 @@ class MakeModule extends Command
 		return [
 			'composer.json' => $this->pathToStub($composer_stub),
 			'src/Providers/StubClassNamePrefixServiceProvider.php' => $this->pathToStub('ServiceProvider.php'),
-			'tests/StubClassNamePrefixServiceProviderTest.php' => $this->pathToStub('ServiceProviderTest.php'),
+			'tests/Feature/Providers/StubClassNamePrefixServiceProviderTest.php' => $this->pathToStub('ServiceProviderTest.php'),
 			'database/migrations/StubMigrationPrefix_set_up_StubModuleName_module.php' => $this->pathToStub('migration.php'),
 			'routes/StubModuleName-routes.php' => $this->pathToStub('web-routes.php'),
 			'resources/views/index.blade.php' => $this->pathToStub('view.blade.php'),

--- a/src/Console/Commands/ModulesSync.php
+++ b/src/Console/Commands/ModulesSync.php
@@ -73,8 +73,6 @@ class ModulesSync extends Command
 		$directory->addAttribute('suffix', 'Test.php');
 		$directory[0] = "./{$modules_directory}/*/tests";
 		
-		$config->formatOutput = true;
-		
 		$this->filesystem->put($config_path, $config->asXML());
 		$this->info('Added "Modules" PHPUnit test suite.');
 	}


### PR DESCRIPTION
This change would put the default service provider in Tests/Feature/Providers/ rather than Tests/
Also, the phpunit config in ModulesSync sets "formatOutput" xml but I'm not seeing anything about that in the phpunit docs and my cli was complaining about it.