### PR TITLE
Handle the renamed static property in `Factory`

### DIFF
--- a/src/Support/DatabaseFactoryHelper.php
+++ b/src/Support/DatabaseFactoryHelper.php
@@ -4,6 +4,7 @@ namespace InterNACHI\Modular\Support;
 
 use Closure;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
 use ReflectionClass;
 
@@ -18,13 +19,13 @@ class DatabaseFactoryHelper
 	
 	public function resetResolvers(): void
 	{
-        if (version_compare(\Illuminate\Foundation\Application::VERSION, '11.43.0', '>=')) {
-            Factory::flushState();
-        } else {
-            $this->unsetProperty(Factory::class, 'modelNameResolver');
-            $this->unsetProperty(Factory::class, 'modelNameResolvers');
-            $this->unsetProperty(Factory::class, 'factoryNameResolver');
-        }
+		if (version_compare(Application::VERSION, '11.43.0', '>=')) {
+			Factory::flushState();
+		} else {
+			$this->unsetProperty(Factory::class, 'modelNameResolver');
+			$this->unsetProperty(Factory::class, 'modelNameResolvers');
+			$this->unsetProperty(Factory::class, 'factoryNameResolver');
+		}
 	}
 	
 	public function modelNameResolver(): Closure
@@ -40,7 +41,7 @@ class DatabaseFactoryHelper
 			// Temporarily disable the modular resolver if we're not in a module
 			try {
 				$this->unsetProperty(Factory::class, 'modelNameResolver');
-                $this->unsetProperty(Factory::class, 'modelNameResolvers');
+				$this->unsetProperty(Factory::class, 'modelNameResolvers');
 				return $factory->modelName();
 			} finally {
 				Factory::guessModelNamesUsing($this->modelNameResolver());
@@ -86,9 +87,8 @@ class DatabaseFactoryHelper
 	protected function unsetProperty($target, $property): void
 	{
 		$reflection = new ReflectionClass($target);
-        if ($reflection->hasProperty($property)) {
-            $reflected = $reflection->getProperty($property);
-            $reflection->setStaticPropertyValue($property, $reflected->getDefaultValue() ?? null);
-        }
+		if ($reflection->hasProperty($property)) {
+			$reflection->setStaticPropertyValue($property, $reflection->getProperty($property)->getDefaultValue());
+		}
 	}
 }


### PR DESCRIPTION
Laravel recently changed `Factory::$modelNameResolver` to `Factory::$modelNameResolvers` in [PR #54644](https://github.com/laravel/framework/pull/54644).

This has made me slightly annoyed because it's broken my test suite.

I've opened an [issue](https://github.com/laravel/framework/issues/54698) mentioning that it's a BC break, I'm guessing that the answer from Laravel will be "why are you touching internal properties?".

Either way, this PR updates the Factory helper to circumvent the bug.