### PR TITLE
add cache filename to config

### DIFF
--- a/config.php
+++ b/config.php
@@ -91,4 +91,15 @@ return [
 	*/
 	
 	'should_discover_events' => null,
+
+	/*
+	|--------------------------------------------------------------------------
+	| Custom cache filename
+	|--------------------------------------------------------------------------
+	|
+	| This is the filename of the cache file that will be used to store the modules configuration.
+	| 
+	*/
+
+	'cache_filename' => 'modules.php',
 ];

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -50,7 +50,7 @@ class ModularServiceProvider extends ServiceProvider
 		$this->app->singleton(ModuleRegistry::class, function() {
 			return new ModuleRegistry(
 				$this->getModulesBasePath(),
-				$this->app->bootstrapPath('cache/modules.php')
+				$this->app->bootstrapPath('cache/' . config('app-modules.cache_filename', 'modules.php'))
 			);
 		});
 		


### PR DESCRIPTION
This way i can run / migrate from nWidart/laravel-modules to this module. They currently use the same cache file.