### PR TITLE
Add vendor:publish support

### DIFF
--- a/src/Console/Commands/Foundation/VendorPublishCommand.php
+++ b/src/Console/Commands/Foundation/VendorPublishCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InterNACHI\Modular\Console\Commands\Foundation;
+
+use Illuminate\Foundation\Events\VendorTagPublished;
+use InterNACHI\Modular\Console\Commands\Modularize;
+use InterNACHI\Modular\Support\ModuleConfig;
+
+class VendorPublishCommand extends \Illuminate\Foundation\Console\VendorPublishCommand
+{
+	use Modularize;
+
+	protected function publishTag($tag)
+	{
+		$pathsToPublish = $this->pathsToPublish($tag);
+
+		if ($publishing = count($pathsToPublish) > 0) {
+			$this->components->info(sprintf(
+				'Publishing %sassets',
+				$tag ? "[$tag] " : '',
+			));
+		}
+
+		$module = $this->module();
+
+		foreach ($pathsToPublish as $from => &$to) {
+			if ($module) {
+				$this->updateTargetPath($module, $to);
+			}
+
+			$this->publishItem($from, $to);
+		}
+
+		if ($publishing === false) {
+			$this->components->info('No publishable resources for tag ['.$tag.'].');
+		} else {
+			$this->laravel['events']->dispatch(new VendorTagPublished($tag, $pathsToPublish));
+
+			$this->newLine();
+		}
+	}
+
+	protected function updateTargetPath(ModuleConfig $module, string &$path)
+	{
+		$base_path = $this->laravel->basePath();
+		$module_path = $module->path();
+
+		$path = str_replace($base_path, $module_path, $path);
+	}
+}

--- a/tests/Commands/Foundation/VendorPublishCommandTest.php
+++ b/tests/Commands/Foundation/VendorPublishCommandTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace InterNACHI\Modular\Tests\Commands\Foundation;
+
+use InterNACHI\Modular\Console\Commands\Foundation\VendorPublishCommand;
+use InterNACHI\Modular\Tests\Concerns\TestsMakeCommands;
+use InterNACHI\Modular\Tests\Concerns\WritesToAppFilesystem;
+use InterNACHI\Modular\Tests\TestCase;
+
+class VendorPublishCommandTest extends TestCase
+{
+	use WritesToAppFilesystem;
+	use TestsMakeCommands;
+
+	public function test_it_overrides_the_default_command(): void
+	{
+		$this->requiresLaravelVersion('9.2.0');
+
+		$this->artisan('vendor:publish', ['--help' => true])
+			->expectsOutputToContain('--module')
+			->assertExitCode(0);
+	}
+
+	public function test_it_published_to_correct_module()
+	{
+		$this->requiresLaravelVersion('9.2.0');
+
+		$command = VendorPublishCommand::class;
+		$arguments = ['--tag' => 'laravel-mail'];
+		$expected_path = 'resources/views/vendor/mail/html/layout.blade.php';
+
+		$this->assertModuleCommandResults($command, $arguments, $expected_path, []);
+	}
+}


### PR DESCRIPTION
It enables configuration files and other publishable assets from external composer dependencies to be published directly into a specific module.

This makes it easier to configure third-party packages used by individual modules without affecting the global application scope.

**Example**
When installing `lucasdotvin/laravel-soulbscription`, we might want to publish its migration and configuration files inside the `Billing` module.

```bash
php artisan vendor:publish --tag=soulbscription-config
php artisan vendor:publish --tag=soulbscription-migrations
```

However, the published configuration file is not automatically loaded.
To load it, we can manually merge the configuration in `BillingServiceProvider`:

```php
public function register(): void
{
    $this->mergeConfigFrom(
         __DIR__ . '/../../config/soulbscription.php',
         'soulbscription'
    );
}
```

This change simplifies that workflow by integrating `vendor:publish` behavior directly with the module system.