### PR TITLE
Add option to ignore module migrations

### DIFF
--- a/config.php
+++ b/config.php
@@ -46,6 +46,21 @@ return [
 	*/
 	
 	'modules_directory' => 'app-modules',
+
+	/*
+    |--------------------------------------------------------------------------
+    | Migrations
+    |--------------------------------------------------------------------------
+    |
+    | Here you can specify which modules should be ignored by the migrator.
+    | This is useful if you want to disable migrations for a specific
+    | module.
+    |
+    */
+
+	'migrations' => [
+		'ignore' => [],
+	],
 	
 	/*
 	|--------------------------------------------------------------------------

--- a/src/Support/ModularServiceProvider.php
+++ b/src/Support/ModularServiceProvider.php
@@ -234,6 +234,10 @@ class ModularServiceProvider extends ServiceProvider
 	{
 		$this->autoDiscoveryHelper()
 			->migrationDirectoryFinder()
+			->reject(function (SplFileInfo $path) {
+				$module = $this->registry()->moduleForPathOrFail($path->getPath());
+				return in_array($module->name, Config::get('app-modules.migrations.ignore', []));
+			})
 			->each(function(SplFileInfo $path) use ($migrator) {
 				$migrator->path($path->getRealPath());
 			});


### PR DESCRIPTION
Adds a `migrations.ignore` configuration key to exclude specified modules from the migration process.

Includes a test to verify the functionality.
________

Hello! Thanks for this great package.

I'm proposing this change to introduce more granular control over the migration process in modular applications.

In complex projects, there's often a need to separate the "core" application migrations from those belonging to specific modules that might be enabled or set up on-demand. For example, one might want to run the main migrations during the initial deployment, but defer the migrations of certain modules to be executed later by a separate process or command.

This feature provides that flexibility by allowing developers to easily exclude certain modules from the default php artisan migrate command. This makes the package even more powerful for managing different deployment scenarios or workflows where not all modules should be migrated at the same time.

I believe this will be a valuable addition for others who need to manage their module migrations in a more controlled manner.

Thanks for your consideration